### PR TITLE
ci: Use postgresql instead of sqlite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,18 @@ node_js:
 cache:
   pip: true
   npm: true
+services:
+- postgresql
+addons:
+  postgresql: '10'
 install:
 - npm install
 - npm run build
 - pip install -r requirements/dev.txt
 - pip install coveralls
+before_script:
+- psql -c 'create database django;' -U postgres
+- psql -c 'create database django_test;' -U postgres
 script:
 - python manage.py collectstatic > /dev/null
 - py.test --cov

--- a/adhocracy-plus/config/settings/test.py
+++ b/adhocracy-plus/config/settings/test.py
@@ -4,3 +4,14 @@ A4_ORGANISATION_FACTORY = 'tests.factories.OrganisationFactory'
 A4_USER_FACTORY = 'tests.factories.UserFactory'
 
 ACCOUNT_EMAIL_VERIFICATION = 'optional'
+
+DATABASES = {
+    'default': {
+        'ENGINE': 'django.db.backends.postgresql_psycopg2',
+        'USER': 'postgres',
+        'NAME': 'django',
+        'TEST': {
+            'NAME': 'django_test'
+        },
+    }
+}


### PR DESCRIPTION
For once because we use it on our production system and also because it is usually more strict.