### PR TITLE
settings: Replace CONTACT_MAIL with a placeholder

### DIFF
--- a/adhocracy-plus/config/settings/base.py
+++ b/adhocracy-plus/config/settings/base.py
@@ -10,7 +10,7 @@ PROJECT_DIR = os.path.dirname(CONFIG_DIR)
 BASE_DIR = os.path.dirname(PROJECT_DIR)
 
 # General settings
-CONTACT_EMAIL = 'support-beteiligung@liqd.net'
+CONTACT_EMAIL = 'contact@domain'
 
 # Application definition
 


### PR DESCRIPTION
We should really stop to set instance specific settings in the project.
Lets use the salt pillars instead.