### PR TITLE
apps/users: Fix language selection on registration

### DIFF
--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -2,6 +2,7 @@ from allauth.account.forms import LoginForm
 from allauth.account.forms import SignupForm
 from allauth.socialaccount.forms import SignupForm as SocialSignupForm
 from django import forms
+from django.utils.translation import get_language
 from django.utils.translation import ugettext_lazy as _
 
 
@@ -28,6 +29,7 @@ class TermsSignupForm(SignupForm):
     def save(self, request):
         user = super(TermsSignupForm, self).save(request)
         user.get_newsletters = self.cleaned_data['get_newsletters']
+        user.language = get_language()
         user.save()
         return user
 
@@ -53,6 +55,7 @@ class SocialTermsSignupForm(SocialSignupForm):
     def save(self, request):
         user = super(SocialTermsSignupForm, self).save(request)
         user.get_newsletters = self.cleaned_data['get_newsletters']
+        user.language = get_language()
         user.save()
         return user
 

--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -5,7 +5,6 @@ from django.db import models
 from django.urls import reverse
 from django.utils import timezone
 from django.utils.functional import cached_property
-from django.utils.translation import get_language
 from django.utils.translation import ugettext_lazy as _
 
 from adhocracy4.images.fields import ConfiguredImageField
@@ -138,14 +137,6 @@ class User(auth_models.AbstractBaseUser, auth_models.PermissionsMixin):
     def get_full_name(self):
         full_name = '%s <%s>' % (self.username, self.email)
         return full_name.strip()
-
-    def signup(self, username, email, commit=True):
-        """Update the fields required for sign-up."""
-        self.username = username
-        self.email = email
-        self.language = get_language()
-        if commit:
-            self.save()
 
     def get_absolute_url(self):
         return reverse('profile', args=[str(self.username)])


### PR DESCRIPTION
The current session language (which again was based on the browser language
or manual selection) was not saved any more after !47.

While on it, make sure it is also set for social logins.