### PR TITLE
deps: Update wagtail to 2.7

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ django-capture-tag==1.0
 django-cloudflare-push==0.2.0
 django-sites==0.10
 raven==6.10.0
-wagtail==2.6.2
+wagtail==2.7 # pyup: <2.8
 whitenoise==4.1.4
 zeep==3.4.0
 


### PR DESCRIPTION
This version is a long term release, so lets pin it until we have
good reasons to update again (lik the django 2.2 update before).