### PR TITLE
webpack: Remove commonjs plugin and reduce supported browsers

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   "repository": "https://github.com/liqd/adhocracy-plus.git",
   "dependencies": {
     "@babel/core": "7.7.5",
-    "@babel/plugin-transform-modules-commonjs": "7.7.5",
     "@babel/plugin-transform-runtime": "7.7.6",
     "@babel/preset-env": "7.7.6",
     "@babel/preset-react": "7.7.4",
@@ -78,7 +77,7 @@
     "build": "webpack --config webpack.dev.js --mode development",
     "watch": "webpack --config webpack.dev.js --watch --mode development"
   },
-  "browserslist": "last 3 versions, ie >= 10",
+  "browserslist": "defaults and not dead and >= 0.5%",
   "husky": {
     "hooks": {
       "pre-commit": "make lint-quick"

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -79,7 +79,7 @@ module.exports = {
         loader: 'babel-loader',
         options: {
           presets: ['@babel/preset-env', '@babel/preset-react'].map(require.resolve),
-          plugins: ['@babel/plugin-transform-runtime', '@babel/plugin-transform-modules-commonjs']
+          plugins: ['@babel/plugin-transform-runtime']
         }
       },
       {


### PR DESCRIPTION
Supporting outdated or rarely used browsers makes everyone else
slower. Let's reduce the list to a reasonable number. We don't test
the other browser anyway, they might be broken without us knowing.