### PR TITLE
webpack: Readd commonjs translation

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   "repository": "https://github.com/liqd/adhocracy-plus.git",
   "dependencies": {
     "@babel/core": "7.7.5",
+    "@babel/plugin-transform-modules-commonjs": "7.7.5",
     "@babel/plugin-transform-runtime": "7.7.6",
     "@babel/preset-env": "7.7.6",
     "@babel/preset-react": "7.7.4",
@@ -77,7 +78,7 @@
     "build": "webpack --config webpack.dev.js --mode development",
     "watch": "webpack --config webpack.dev.js --watch --mode development"
   },
-  "browserslist": "defaults and not dead and >= 0.5%",
+  "browserslist": "last 3 versions, ie >= 10",
   "husky": {
     "hooks": {
       "pre-commit": "make lint-quick"

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "build": "webpack --config webpack.dev.js --mode development",
     "watch": "webpack --config webpack.dev.js --watch --mode development"
   },
-  "browserslist": "last 3 versions, ie >= 10",
+  "browserslist": "defaults and not dead and >= 0.5%",
   "husky": {
     "hooks": {
       "pre-commit": "make lint-quick"

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -79,7 +79,7 @@ module.exports = {
         loader: 'babel-loader',
         options: {
           presets: ['@babel/preset-env', '@babel/preset-react'].map(require.resolve),
-          plugins: ['@babel/plugin-transform-runtime']
+          plugins: ['@babel/plugin-transform-runtime', '@babel/plugin-transform-modules-commonjs']
         }
       },
       {


### PR DESCRIPTION
Removing the commonjs produced errors that the linter didn't catch:
mixing es5 and es6 classes is actually not supported by browsers,
but we do it in our code. As long as we don't clean that up, let's
stick to the commonjs translation which works around this.