### PR TITLE
languages: force site to be in german, hide switch from header, and h…

### DIFF
--- a/adhocracy-plus/templates/base.html
+++ b/adhocracy-plus/templates/base.html
@@ -1,9 +1,9 @@
 <!DOCTYPE html>
-{% load absolute_url i18n organisation_tags static wagtailimages_tags wagtailsettings_tags wagtailuserbar %}
-{% get_current_language as LANGUAGE_CODE %}
+{% load absolute_url i18n force_translation organisation_tags static wagtailimages_tags wagtailsettings_tags wagtailuserbar %}
 {% get_current_organisation as ORGANISATION %}
-<html lang="{{ LANGUAGE_CODE }}">
+<html lang="de">
 <head>
+    {% force_translation 'de' %}
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
     <title>{% block title %}adhocracy+{% if ORGANISATION %}/{{ ORGANISATION.name }}{% endif %}{% endblock %}</title>
@@ -55,8 +55,10 @@
     {% block extra_js %}
         {# Override this in templates to add extra javascript #}
     {% endblock %}
+    {% endforce_translation %}
 </head>
 <body>
+    {% force_translation 'de' %}
     {% wagtailuserbar %}
     <div class="min-height__wrapper d-flex flex-column">
         <a href="#main" class="sr-only sr-only-focusable">{% trans "Skip to content "%}</a>
@@ -111,5 +113,6 @@
         {% endif %}
         {% endblock %}
     </div>
+    {% endforce_translation %}
 </body>
 </html>

--- a/adhocracy-plus/templates/header.html
+++ b/adhocracy-plus/templates/header.html
@@ -12,7 +12,6 @@
             {% include 'includes/header_logo_link.html' %}
         </div>
         <nav class="main-header__nav">
-            {% include 'includes/header_language_switch.html' %}
             {% if ORGANISATION.logo %}
             {% url 'organisation' organisation_slug=ORGANISATION.slug as organisation_url %}
             {% if not request.get_full_path == organisation_url %}

--- a/adhocracy-plus/templates/header_dashboard.html
+++ b/adhocracy-plus/templates/header_dashboard.html
@@ -9,7 +9,6 @@
             {% include 'includes/header_logo_link.html' %}
         </div>
         <nav class="main-header__nav">
-            {% include 'includes/header_language_switch.html' %}
             <div class="main-header__mobile-menu {% if not ORGANISATION %}main-header__mobile-menu--platform{% endif %} collapse" id="main-header-collapse">
                 <div class="main-header__user">
                     {% userindicator %}

--- a/apps/account/templates/a4_candy_account/profile.html
+++ b/apps/account/templates/a4_candy_account/profile.html
@@ -10,7 +10,7 @@
         {% csrf_token %}
 
         {% for field in form %}
-            {% if not field.name == 'get_notifications' and not field.name == 'get_newsletters' %}
+            {% if not field.name == 'get_notifications' and not field.name == 'get_newsletters' and not field.name == 'language' %}
             {% include 'a4_candy_contrib/includes/form_field.html' with field=field %}
             {% endif %}
         {% endfor %}

--- a/apps/contrib/templatetags/force_translation.py
+++ b/apps/contrib/templatetags/force_translation.py
@@ -1,0 +1,48 @@
+import re
+
+from django.template import Library
+from django.template import Node
+from django.template import TemplateSyntaxError
+from django.utils import translation
+
+register = Library()
+
+
+class ForceTransNode(Node):
+    def __init__(self, nodelist, language_name):
+        self.nodelist = nodelist
+        self.language_name = language_name
+
+    def render(self, context):
+        with translation.override(self.language_name):
+            return self.nodelist.render(context)
+
+
+def force_translation(parser, token):
+    """
+    Parse force_translation template tag.
+
+    .. code:: django
+      {% force_translation 'en' %}
+          {{ _('Will always be english') }}
+      {% endforce_translation %}
+    """
+    try:
+        nodelist = parser.parse(('endforce_translation',))
+        parser.delete_first_token()
+        tag_name, language_name = token.split_contents()
+    except ValueError:
+        raise TemplateSyntaxError(
+            '{} tag requires arguments'.format(token.contents.split()[0])
+        )
+    match = re.match(r'["\']([a-z]{2}(:?_[A-Z]{2}})?)["\']', language_name)
+    if not match:
+        raise TemplateSyntaxError(
+            '{} locale should be in ll[_LL] format and in quotes'.format(
+                tag_name
+            )
+        )
+    return ForceTransNode(nodelist, match.group(1))
+
+
+register.tag('force_translation', force_translation)


### PR DESCRIPTION
…ide form field from user settings

Uh, this is quite a hack, but seems to be the easiest solution with no migrations or changes to the tests.
It forces all templates to be German with the force-templatetag, 
hides the switch from the header,
and hides the form field from the user settings. I did hide that and didn't remove it from the form, because the latter would also mean that we needed to change the form_valid in the views.