### PR TITLE
Revert "settings: set default user language and site-wide default to same lan…"

### DIFF
--- a/adhocracy-plus/config/settings/base.py
+++ b/adhocracy-plus/config/settings/base.py
@@ -176,7 +176,7 @@ DATABASES = {
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/
 
-LANGUAGE_CODE = 'de'
+LANGUAGE_CODE = 'en'
 DEFAULT_USER_LANGUAGE_CODE = 'de'
 
 TIME_ZONE = 'Europe/Berlin'


### PR DESCRIPTION
Reverts liqd/adhocracy-plus#396

Well, this broke the migrations where pgettext is used (in a4/comments/models/meta)