### PR TITLE
templates/profile: Add hidden language field

### DIFF
--- a/apps/account/templates/a4_candy_account/profile.html
+++ b/apps/account/templates/a4_candy_account/profile.html
@@ -18,6 +18,8 @@
         {% include 'a4_candy_contrib/includes/form_checkbox_field.html' with field=form.get_notifications %}
         {% include 'a4_candy_contrib/includes/form_checkbox_field.html' with field=form.get_newsletters %}
 
+        <input type="hidden" name="{{ form.language.name }}" value="{{ form.language.value }}"/>
+
         <div class="mb-3">
             <button type="submit" class="btn btn--primary">{% trans 'Save changes'%}</button>
         </div>


### PR DESCRIPTION
We hide the language field so the platform is german only. But apparently it
is mandatory for the backend, so it would not accept post actions that don't
include the language field.

fixes https://github.com/liqd/adhocracy-plus/issues/425