### PR TITLE
templates/base: Add 'trans' tag

### DIFF
--- a/adhocracy-plus/templates/base.html
+++ b/adhocracy-plus/templates/base.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-{% load absolute_url i18n organisation_tags static wagtailimages_tags wagtailsettings_tags wagtailuserbar %}
+{% load absolute_url i18n organisation_tags static trans wagtailimages_tags wagtailsettings_tags wagtailuserbar %}
 {% get_current_language as LANGUAGE_CODE %}
 {% get_current_organisation as ORGANISATION %}
 <html lang="{{ LANGUAGE_CODE }}">


### PR DESCRIPTION
This apparently only affect wagtail simple pages - everywhere else we
load the `trans` tag at some other place.

Should fix https://sentry.liqd.net/sentry/aplus-prod/issues/994/