### PR TITLE
cms/blocks: load i18n template tag

### DIFF
--- a/apps/cms/pages/templates/a4_candy_cms_pages/blocks/download_block.html
+++ b/apps/cms/pages/templates/a4_candy_cms_pages/blocks/download_block.html
@@ -1,4 +1,4 @@
-{% load contrib_tags %}
+{% load i18n contrib_tags %}
 <div class="block-download mb-3 pb-1">
     <a href="{{ value.document.url }}"><span class="sr-only">{% trans 'Download' %} </span>{% if value.title %}{{ value.title }}{% else %}{{ value.document.title }}{% endif %}</a>
     <div class="block-download__info">{% if value.document_type %}{{ value.document_type }}{% else %}{{ value.document.file_extension }}{% endif %} | {{ value.document.file_size | devide:1048576 }} MB</div>


### PR DESCRIPTION
Fixes 500 on simple pages with a document download added.

Fixes https://sentry.liqd.net/sentry/aplus-prod/issues/994/