### PR TITLE
emails: Always add organisation to context in EmailAplus

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,10 +67,7 @@ watch:
 
 .PHONY: background
 background:
-	trap 'kill %1; kill %2' KILL; \
-	npm run watch & \
-	$(VIRTUAL_ENV)/bin/python3 manage.py process_tasks & \
-	$(VIRTUAL_ENV)/bin/python3 manage.py runserver 8004
+	$(VIRTUAL_ENV)/bin/python3 manage.py process_tasks
 
 .PHONY: test
 test:

--- a/apps/projects/emails.py
+++ b/apps/projects/emails.py
@@ -1,5 +1,6 @@
 from email.mime.image import MIMEImage
 
+from apps.organisations.models import Organisation
 from apps.projects import tasks
 from apps.users.emails import EmailAplus as Email
 
@@ -25,11 +26,6 @@ class InviteParticipantEmail(Email):
 
         return attachments
 
-    def get_context(self):
-        context = super().get_context()
-        context['organisation'] = self.object.project.organisation
-        return context
-
 
 class InviteModeratorEmail(Email):
     template_name = 'a4_candy_projects/emails/invite_moderator'
@@ -52,11 +48,6 @@ class InviteModeratorEmail(Email):
 
         return attachments
 
-    def get_context(self):
-        context = super().get_context()
-        context['organisation'] = self.object.project.organisation
-        return context
-
 
 class DeleteProjectEmail(Email):
     template_name = 'a4_candy_projects/emails/delete_project'
@@ -69,7 +60,7 @@ class DeleteProjectEmail(Email):
             'initiators': list(organisation.initiators.all()
                                .distinct()
                                .values_list('email', flat=True)),
-            'organisation': organisation.name
+            'organisation_id': organisation.id
         }
         tasks.send_async_no_object(
             cls.__module__, cls.__name__,
@@ -77,7 +68,7 @@ class DeleteProjectEmail(Email):
         return []
 
     def get_organisation(self):
-        return self.object['organisation']
+        return Organisation.objects.get(id=self.object['organisation_id'])
 
     def get_receivers(self):
         return self.object['initiators']
@@ -85,5 +76,4 @@ class DeleteProjectEmail(Email):
     def get_context(self):
         context = super().get_context()
         context['name'] = self.object['name']
-        context['organisation'] = self.object['organisation']
         return context

--- a/apps/projects/templates/a4_candy_projects/emails/delete_project.de.email
+++ b/apps/projects/templates/a4_candy_projects/emails/delete_project.de.email
@@ -6,4 +6,4 @@
 
 {% block content %}Das Projekt "{{ name }}" auf der Beteiligungsplattform {{ site.name }} wurde gelöscht.{% endblock  %}
 
-{% block reason %}Diese E-Mail wurde an {{ receiver }} gesendet. Die E-Mail wurde an Sie gesendet, da Sie Initiator*in der Organisation '{{ organisation }}' sind, in der ein Projekt gelöscht wurde.{% endblock %}
+{% block reason %}Diese E-Mail wurde an {{ receiver }} gesendet. Die E-Mail wurde an Sie gesendet, da Sie Initiator*in der Organisation '{{ organisation.name }}' sind, in der ein Projekt gelöscht wurde.{% endblock %}

--- a/apps/projects/templates/a4_candy_projects/emails/delete_project.en.email
+++ b/apps/projects/templates/a4_candy_projects/emails/delete_project.en.email
@@ -6,4 +6,4 @@
 
 {% block content %}The project "{{ name }}" on the participation platform {{ site.name }} was deleted.{% endblock  %}
 
-{% block reason %}This email was sent to {{ receiver }}. This email was sent to you because you are an initiator of the '{{ organisation }}', in wich a project was deleted.{% endblock %}
+{% block reason %}This email was sent to {{ receiver }}. This email was sent to you because you are an initiator of the '{{ organisation.name }}', in wich a project was deleted.{% endblock %}

--- a/apps/users/emails.py
+++ b/apps/users/emails.py
@@ -24,3 +24,8 @@ class EmailAplus(Email):
         except User.DoesNotExist:
             res = super().get_languages(receiver)
         return res
+
+    def get_context(self):
+        context = super().get_context()
+        context['organisation'] = self.get_organisation()
+        return context


### PR DESCRIPTION
From the relevant commit:
```
This makes most mails use the organisation settings/logo, especially notifications.

Also corrects the project delete email to return a proper organisation object
on `get_organisation()` to be in line with other mails.
```

Fixes https://github.com/liqd/adhocracy-plus/issues/465