### PR TITLE
emails: Move organisation logo attachment to EmailAplus

### DIFF
--- a/apps/newsletters/emails.py
+++ b/apps/newsletters/emails.py
@@ -1,5 +1,3 @@
-from email.mime.image import MIMEImage
-
 from django.apps import apps
 from django.conf import settings
 from django.contrib import auth
@@ -35,18 +33,6 @@ class NewsletterEmail(ReportToAdminEmailMixin, Email):
             .filter(get_newsletters=True)\
             .filter(is_active=True)\
             .distinct()
-
-    def get_attachments(self):
-        attachments = super().get_attachments()
-
-        organisation = self.kwargs['organisation']
-        if organisation and organisation.logo:
-            f = open(organisation.logo.path, 'rb')
-            logo = MIMEImage(f.read())
-            logo.add_header('Content-ID', '<{}>'.format('organisation_logo'))
-            attachments += [logo]
-
-        return attachments
 
 
 class NewsletterEmailAll(NewsletterEmail):

--- a/apps/projects/emails.py
+++ b/apps/projects/emails.py
@@ -1,5 +1,3 @@
-from email.mime.image import MIMEImage
-
 from apps.organisations.models import Organisation
 from apps.projects import tasks
 from apps.users.emails import EmailAplus as Email
@@ -14,18 +12,6 @@ class InviteParticipantEmail(Email):
     def get_receivers(self):
         return [self.object.email]
 
-    def get_attachments(self):
-        attachments = super().get_attachments()
-
-        organisation = self.object.project.organisation
-        if organisation and organisation.logo:
-            f = open(organisation.logo.path, 'rb')
-            logo = MIMEImage(f.read())
-            logo.add_header('Content-ID', '<{}>'.format('organisation_logo'))
-            attachments += [logo]
-
-        return attachments
-
 
 class InviteModeratorEmail(Email):
     template_name = 'a4_candy_projects/emails/invite_moderator'
@@ -35,18 +21,6 @@ class InviteModeratorEmail(Email):
 
     def get_receivers(self):
         return [self.object.email]
-
-    def get_attachments(self):
-        attachments = super().get_attachments()
-
-        organisation = self.object.project.organisation
-        if organisation and organisation.logo:
-            f = open(organisation.logo.path, 'rb')
-            logo = MIMEImage(f.read())
-            logo.add_header('Content-ID', '<{}>'.format('organisation_logo'))
-            attachments += [logo]
-
-        return attachments
 
 
 class DeleteProjectEmail(Email):

--- a/apps/users/emails.py
+++ b/apps/users/emails.py
@@ -1,3 +1,5 @@
+from email.mime.image import MIMEImage
+
 from adhocracy4.emails import Email
 
 from .models import User
@@ -29,3 +31,15 @@ class EmailAplus(Email):
         context = super().get_context()
         context['organisation'] = self.get_organisation()
         return context
+
+    def get_attachments(self):
+        attachments = super().get_attachments()
+
+        organisation = self.get_organisation()
+        if organisation and organisation.logo:
+            f = open(organisation.logo.path, 'rb')
+            logo = MIMEImage(f.read())
+            logo.add_header('Content-ID', '<{}>'.format('organisation_logo'))
+            attachments += [logo]
+
+        return attachments


### PR DESCRIPTION
All mail classes inheriting from EmailAplus need to attach the organisation
logo - so move the code there. Fixes certain emails lacking any logo.