### PR TITLE
users/forms: Add autocomplete hints

### DIFF
--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -23,6 +23,9 @@ class DefaultLoginForm(LoginForm):
         self.fields['login'].label = _('Username/e-mail')
         del self.fields['login'].widget.attrs['placeholder']
         del self.fields['password'].widget.attrs['placeholder']
+        self.fields['login'].widget.attrs['autocomplete'] = 'username'
+        self.fields['password'].widget.attrs['autocomplete'] = \
+            'current-password'
 
 
 class DefaultSignupForm(SignupForm):
@@ -46,6 +49,9 @@ class DefaultSignupForm(SignupForm):
         del self.fields['email'].widget.attrs['placeholder']
         del self.fields['password1'].widget.attrs['placeholder']
         del self.fields['password2'].widget.attrs['placeholder']
+        self.fields['email'].widget.attrs['autocomplete'] = 'username'
+        self.fields['password1'].widget.attrs['autocomplete'] = 'new-password'
+        self.fields['password2'].widget.attrs['autocomplete'] = 'new-password'
 
     def save(self, request):
         user = super().save(request)


### PR DESCRIPTION
Add proper hints to login and signup forms so browsers do not use the wrong
forms for password saving. This is especially visibile when we have extra
fields, like in the IG-BCE form.

Fixes https://github.com/liqd/adhocracy-plus/issues/449