### PR TITLE
deps: Remove deprecated popper.js

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,6 @@
     "mini-css-extract-plugin": "0.9.0",
     "node-sass": "4.13.1",
     "postcss-loader": "3.0.0",
-    "popper.js": "1.16.1",
     "react-flip-move": "3.0.4",
     "sass-loader": "8.0.2",
     "sass-planifolia": "0.6.0",


### PR DESCRIPTION
Apparently a newer version is either installed as dependecy or it
is bundled in - either way, this package version got deprecated and
won't install any more and things appear to work just fine without it.