### PR TITLE
templates/email_base: Add HTML tag for unused logo

### DIFF
--- a/adhocracy-plus/templates/email_base.html
+++ b/adhocracy-plus/templates/email_base.html
@@ -12,6 +12,7 @@
         <td style="padding-top: 20px; text-align: center;" align="center">
           {% if organisation and organisation.logo %}
             <img src="cid:organisation_logo" style="width: 15%;" alt="Logo" >
+            <img src="cid:logo" style="display: none;" >
           {% else %}
             <img src="cid:logo" style="width: 15%;" alt="Logo" >
           {% endif %}


### PR DESCRIPTION
Otherwise certain clients like the MacOS mail client chooses to
display the attached logo anyways.

Fixes https://github.com/liqd/adhocracy-plus/issues/262