### PR TITLE
assets: Replace jQuery 'a4.embed.ready' listeners with vanilla js

### DIFF
--- a/adhocracy-plus/assets/js/app.js
+++ b/adhocracy-plus/assets/js/app.js
@@ -23,7 +23,7 @@ import * as ReactPolls from '../../../apps/polls/assets/react_polls.jsx'
 import * as ReactQuestions from '../../../apps/questions/assets/react_questions.jsx'
 import * as ReactQuestionsPresent from '../../../apps/questions/assets/react_questions_present.jsx'
 
-var initialiseWidget = function (namespace, name, fn) {
+function initialiseWidget (namespace, name, fn) {
   var key = 'data-' + namespace + '-widget'
   var selector = '[' + key + '=' + name + ']'
   $(selector).each(function (i, el) {
@@ -34,7 +34,7 @@ var initialiseWidget = function (namespace, name, fn) {
   })
 }
 
-var init = function () {
+function init () {
   initialiseWidget('a4', 'comment', ReactComments.renderComment)
   initialiseWidget('a4', 'comment_async', ReactCommentsAsync.renderComment)
   initialiseWidget('a4', 'follows', ReactFollows.renderFollow)
@@ -63,9 +63,8 @@ var init = function () {
   })
 }
 
-$(init)
-window.init_widgets = init
-$(document).on('a4.embed.ready', init)
+document.addEventListener('DOMContentLoaded', init, false)
+document.addEventListener('a4.embed.ready', init, false)
 
 // Closes bootstrap collapse on click elsewhere
 $(document).on('click', function () {

--- a/adhocracy-plus/assets/js/popover.js
+++ b/adhocracy-plus/assets/js/popover.js
@@ -1,6 +1,6 @@
 (function (init) {
-  $(init)
-  $(document).on('a4.embed.ready', init)
+  document.addEventListener('DOMContentLoaded', init, false)
+  document.addEventListener('a4.embed.ready', init, false)
 })(function () {
   $('[data-toggle="popover"]').popover()
 })

--- a/apps/embed/assets/embed.js
+++ b/apps/embed/assets/embed.js
@@ -94,8 +94,8 @@ $(document).ready(function () {
     $main.empty()
     $main.append($top)
     $main.append($root.find('main').children())
-    $(document).trigger('a4.embed.ready')
-    $(window.init_widgets)
+
+    document.dispatchEvent(new Event('a4.embed.ready'))
 
     // jump to top after navigation
     $top.focus()

--- a/apps/maps/assets/map-address.js
+++ b/apps/maps/assets/map-address.js
@@ -106,9 +106,7 @@ var renderPoints = function (points) {
   }
 }
 
-var init = function () {
-  var $ = window.jQuery
-
+function init () {
   $('[data-map="address"]').each(function (i, e) {
     var $group = $(e)
     var name = $group.data('name')
@@ -155,5 +153,5 @@ var init = function () {
   })
 }
 
-window.jQuery(init)
-window.jQuery(document).on('a4.embed.ready', init)
+document.addEventListener('DOMContentLoaded', init, false)
+document.addEventListener('a4.embed.ready', init, false)

--- a/apps/maps/assets/map_choose_polygon_with_preset.js
+++ b/apps/maps/assets/map_choose_polygon_with_preset.js
@@ -19,8 +19,7 @@ function getBaseBounds (L, polygon, bbox) {
   }
 }
 
-var init = function () {
-  const $ = window.jQuery
+function init () {
   const L = window.L
 
   const ImportControl = L.Control.extend({
@@ -295,5 +294,5 @@ var init = function () {
   })
 }
 
-window.jQuery(init)
-window.jQuery(document).on('a4.embed.ready', init)
+document.addEventListener('DOMContentLoaded', init, false)
+document.addEventListener('a4.embed.ready', init, false)

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@babel/runtime": "7.9.2",
     "@fortawesome/fontawesome-free": "5.13.0",
     "acorn": "7.1.1",
-    "adhocracy4": "liqd/adhocracy4#fa99979f80d08f3cc17a737d5e78f3e5d1e8ed67",
+    "adhocracy4": "liqd/adhocracy4#d21a787094685c48151f211ca3ad7cade0a3c229",
     "autoprefixer": "9.7.5",
     "axios": "0.19.2",
     "babel-loader": "8.1.0",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+git://github.com/liqd/adhocracy4.git@fa99979f80d08f3cc17a737d5e78f3e5d1e8ed67#egg=adhocracy4
+git+git://github.com/liqd/adhocracy4.git@d21a787094685c48151f211ca3ad7cade0a3c229#egg=adhocracy4
 
 # Additional requirements
 bcrypt==3.1.7


### PR DESCRIPTION
When using multple webpack endpoints we do not get a global jQuery
object but instead one for each endpoint. These do not see each others
signals, thus do not fire.

Use standard js events instead - they don't suffer from that problem and
we should get rid of jQuery anyway over time.

Also use the chance to clean up the init syntax.

Depends on https://github.com/liqd/adhocracy4/pull/519