### PR TITLE
Revert "Update dependency jquery to v3.5.0"

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "file-loader": "6.0.0",
     "file-saver": "2.0.2",
     "immutability-helper": "3.0.2",
-    "jquery": "3.5.0",
+    "jquery": "3.4.1",
     "leaflet": "1.6.0",
     "leaflet-draw": "1.0.4",
     "leaflet.markercluster": "1.4.1",


### PR DESCRIPTION
Reverts liqd/adhocracy-plus#537
above update breaks header dropdown on mobile, will look at proper fix after I have finished work on header, for now it needs to work for mobile testing