### PR TITLE
apps/users: remove standard email logo from attachment if not needed

### DIFF
--- a/apps/users/emails.py
+++ b/apps/users/emails.py
@@ -45,5 +45,9 @@ class EmailAplus(Email):
             logo = MIMEImage(f.read())
             logo.add_header('Content-ID', '<{}>'.format('organisation_logo'))
             attachments += [logo]
+            # need to remove standard email logo bc some email clients
+            # display all attachments, even if not used
+            attachments = [a for a in attachments
+                           if a['Content-Id'] != '<logo>']
 
         return attachments


### PR DESCRIPTION
fixes #554
Apparently MacOS client (and maybe others) display all images that are attached, even if they are not used. One can suppress this behaviour with display=False, but the image is still sent in the attachments.
That is why I thought maybe its better to completely remove the a+ logo from the attachment if the organisation logo is used. What do you think?