### PR TITLE
locale/nl_NL: remove wrong quotation marks that break links

### DIFF
--- a/locale/nl_NL/LC_MESSAGES/django.po
+++ b/locale/nl_NL/LC_MESSAGES/django.po
@@ -2,18 +2,19 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 # Translators:
 # Joop Laan <joop@interconnecting.systems>, 2020
-#
+# Katharina Schmid <k.schmid@liqd.net>, 2020
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: a4-meinberlin\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 13:50+0200\n"
+"POT-Creation-Date: 2020-07-17 16:07+0200\n"
 "PO-Revision-Date: 2020-06-26 14:15+0000\n"
-"Last-Translator: Joop Laan <joop@interconnecting.systems>, 2020\n"
+"Last-Translator: Katharina Schmid <k.schmid@liqd.net>, 2020\n"
 "Language-Team: Dutch (Netherlands) (https://www.transifex.com/liqd/teams/111081/nl_NL/)\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
@@ -36,7 +37,7 @@ msgid "Add category"
 msgstr "Categorie toevoegen"
 
 #: adhocracy4/dashboard/templates/a4dashboard/base_dashboard.html:4
-#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:49
+#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:51
 msgid "Dashboard"
 msgstr "Dashboard"
 
@@ -48,7 +49,7 @@ msgstr "Projectinstellingen"
 #: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:15
 #: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:33
 #: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:40
-#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:84
+#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:86
 msgid "Missing fields for publication"
 msgstr "Ontbrekende velden voor publicatie"
 
@@ -524,7 +525,7 @@ msgstr "Project succesvol gedupliceerd."
 msgid "Project successfully created."
 msgstr "Project met succes gecreëerd."
 
-#: adhocracy4/dashboard/views.py:154 apps/dashboard/views.py:120
+#: adhocracy4/dashboard/views.py:154 apps/dashboard/views.py:121
 msgid "Invalid action"
 msgstr "Ongeldige actie"
 
@@ -663,7 +664,7 @@ msgid ""
 "string \"false\" without quotation marks."
 msgstr ""
 "Voer een geldig GeoJSON-object in. Om een nieuw gebied te initialiseren "
-"voert u het woord “false” in zonder aanhalingstekens."
+"voert u het woord \"false\" in zonder aanhalingstekens."
 
 #: adhocracy4/maps/fields.py:17
 msgid "Geometry as GeoJSON"
@@ -800,7 +801,7 @@ msgid "Images"
 msgstr "Afbeeldingen"
 
 #: adhocracy4/projects/admin.py:59 apps/projects/admin.py:55
-#: adhocracy-plus/templates/email_base.html:113
+#: adhocracy-plus/templates/email_base.html:114
 #: adhocracy-plus/templates/footer.html:58
 msgid "Contact"
 msgstr "Contact"
@@ -875,7 +876,7 @@ msgid ""
 msgstr ""
 "Deze beschrijving moet de deelnemers vertellen wat het doel van het project "
 "is hoe de deelname aan het project eruit zal zien. Het zal altijd zichtbaar "
-"zijn in de “Info” tab op de pagina van uw project."
+"zijn in de \"Info\" tab op de pagina van uw project."
 
 #: adhocracy4/projects/models.py:208
 msgid "Results of your project"
@@ -1023,22 +1024,22 @@ msgstr "Aantal"
 #, python-format
 msgid "%(name)s added a new <a href=\"%(comment_url)s\">comment</a>"
 msgstr ""
-"%(name)s heeft een nieuwe <a href=“%(comment_url)s”>reactie</a> toegevoegd"
+"%(name)s heeft een nieuwe <a href=\"%(comment_url)s\">reactie</a> toegevoegd"
 
 #: apps/actions/templates/a4_candy_actions/includes/action.html:10
 #, python-format
 msgid "%(name)s updated a <a href=\"%(comment_url)s\">comment</a>"
-msgstr "%(name)s heeft een <a href=“%(comment_url)s”>reactie</a> bijgewerkt"
+msgstr "%(name)s heeft een <a href=\"%(comment_url)s\">reactie</a> bijgewerkt"
 
 #: apps/actions/templates/a4_candy_actions/includes/action.html:12
 #, python-format
 msgid "%(name)s added a new <a href=\"%(item_url)s\">item</a>"
-msgstr "%(name)s heeft een nieuw <a href=“%(item_url)s”>item</a> toegevoegd"
+msgstr "%(name)s heeft een nieuw <a href=\"%(item_url)s\">item</a> toegevoegd"
 
 #: apps/actions/templates/a4_candy_actions/includes/action.html:14
 #, python-format
 msgid "%(name)s updated an <a href=\"%(item_url)s\">item</a>"
-msgstr "%(name)s heeft een <a href=“%(item_url)s”>item</a> bijgewerkt"
+msgstr "%(name)s heeft een <a href=\"%(item_url)s\">item</a> bijgewerkt"
 
 #: apps/actions/templates/a4_candy_actions/includes/action.html:16
 msgid "New participation started"
@@ -1051,7 +1052,7 @@ msgstr "De participatiefase loopt binnenkort ten einde:"
 #: apps/actions/templates/a4_candy_actions/includes/action.html:23
 #, python-format
 msgid "on <a href=\"%(url)s\">%(name)s</a>"
-msgstr "op <a href=“%(url)s”>%(name)s</a>"
+msgstr "op <a href=\"%(url)s\">%(name)s</a>"
 
 #: apps/activities/dashboard.py:14
 msgid "Face-to-Face Information"
@@ -1230,7 +1231,7 @@ msgstr "Inzoomen"
 msgid "Zoom out"
 msgstr "Uitzoomen"
 
-#: apps/budgeting/templates/a4_candy_budgeting/proposal_list.html:55
+#: apps/budgeting/templates/a4_candy_budgeting/proposal_list.html:64
 #: apps/debate/templates/a4_candy_debate/subject_dashboard_list.html:26
 #: apps/debate/templates/a4_candy_debate/subject_list.html:25
 #: apps/ideas/templates/a4_candy_ideas/idea_list.html:34
@@ -1583,8 +1584,8 @@ msgstr "Acties"
 #: apps/debate/templates/a4_candy_debate/includes/subject_dashboard_list_item.html:24
 #: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_list_item.html:25
 #: apps/topicprio/templates/a4_candy_topicprio/includes/topic_dashboard_list_item.html:24
-#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:60
 #: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:61
+#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:62
 msgid "Delete"
 msgstr "Verwijderen"
 
@@ -1740,11 +1741,11 @@ msgstr ""
 "Voeg een module toe uit de lijst. U kunt later meer modules aan het project "
 "toevoegen, bewerken of weer verwijderen."
 
-#: apps/dashboard/views.py:50
+#: apps/dashboard/views.py:51
 msgid "The module was created"
 msgstr "De module is gemaakt"
 
-#: apps/dashboard/views.py:137
+#: apps/dashboard/views.py:139
 msgid "Module is already added"
 msgstr "Module is reeds toegevoegd"
 
@@ -1752,33 +1753,31 @@ msgstr "Module is reeds toegevoegd"
 msgid "Module cannot be added. Required fields are missing."
 msgstr ""
 
-#: apps/dashboard/views.py:148
+#: apps/dashboard/views.py:160
 msgid "The module is displayed in the project."
 msgstr "De module wordt in het project weergegeven."
 
-#: apps/dashboard/views.py:153
+#: apps/dashboard/views.py:165
 msgid "Module is already removed"
 msgstr "Module is al verwijderd"
 
-#: apps/dashboard/views.py:157
+#: apps/dashboard/views.py:169
 msgid "Module cannot be removed from a published project."
 msgstr "Module kan niet worden verwijderd uit een gepubliceerd project."
 
-#: apps/dashboard/views.py:162
-msgid "Module cannot be removed. It is the only module added to the project."
-msgstr ""
-"De module kan niet worden verwijderd. Het is de enige module die aan het "
-"project is toegevoegd."
-
-#: apps/dashboard/views.py:174
+#: apps/dashboard/views.py:181
 msgid "The module is no longer displayed in the project."
 msgstr "De module wordt niet meer weergegeven in het project."
 
-#: apps/dashboard/views.py:182
+#: apps/dashboard/views.py:189
 msgid "The module has been deleted"
 msgstr "De module is verwijderd"
 
-#: apps/dashboard/views.py:215
+#: apps/dashboard/views.py:194
+msgid "Module cannot be deleted. It has to be removed from the project first."
+msgstr ""
+
+#: apps/dashboard/views.py:239
 msgid "Project was created."
 msgstr "Project is gecreëerd."
 
@@ -1945,8 +1944,8 @@ msgid ""
 "You need to login first. By clicking \"Login\" a popup will open so you can "
 "sign in safely. Do you want to login now?"
 msgstr ""
-"U moet eerst inloggen. Door op “Inloggen” te klikken wordt een popup geopend"
-" zodat u zich veilig kunt aanmelden. Wilt u nu inloggen?"
+"U moet eerst inloggen. Door op \"Inloggen\" te klikken wordt een popup "
+"geopend zodat u zich veilig kunt aanmelden. Wilt u nu inloggen?"
 
 #: apps/embed/templates/a4_candy_embed/includes/project_embed_code.html:4
 msgid "Embed Code"
@@ -2252,15 +2251,15 @@ msgstr "Ontvangers"
 #: apps/newsletters/templates/a4_candy_newsletters/emails/newsletter_email.en.email:10
 #, python-format
 msgid ""
-"This email was sent to %(receiver_mail)s. This email was sent to you because "
-"you are registered on %(site_name)s. If you don't want to receive "
+"This email was sent to %(receiver_mail)s. This email was sent to you because"
+" you are registered on %(site_name)s. If you don't want to receive "
 "newsletters anymore, you may disable them in your user account settings."
 msgstr ""
 
 #: apps/newsletters/templates/a4_candy_newsletters/restricted_newsletter_dashboard_form.html:4
-#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:56
-#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:82
-#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:97
+#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:58
+#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:84
+#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:99
 msgid "Newsletter"
 msgstr "Nieuwsbrief"
 
@@ -2447,8 +2446,8 @@ msgstr ""
 #: apps/notifications/templates/a4_candy_notifications/emails/notify_initiators_project_created.en.email:13
 #, python-format
 msgid ""
-"This email was sent to %(receiver_mail)s. This email was sent to you because "
-"you are an intiator of %(organisation_name)s."
+"This email was sent to %(receiver_mail)s. This email was sent to you because"
+" you are an intiator of %(organisation_name)s."
 msgstr ""
 
 #: apps/notifications/templates/a4_candy_notifications/emails/notify_moderator.en.email:7
@@ -2523,7 +2522,8 @@ msgstr ""
 
 #: apps/notifications/templates/a4_candy_notifications/emails/notify_moderator.en.email:39
 #, python-format
-msgid "on the project %(project_name)s a proposal was added by %(actor_name)s."
+msgid ""
+"on the project %(project_name)s a proposal was added by %(actor_name)s."
 msgstr ""
 
 #: apps/notifications/templates/a4_candy_notifications/emails/notify_moderator.en.email:41
@@ -2551,8 +2551,8 @@ msgstr ""
 #: apps/notifications/templates/a4_candy_notifications/emails/notify_moderator.en.email:65
 #, python-format
 msgid ""
-"This email was sent to %(receiver_mail)s. This email was sent to you because "
-"you are a moderator in the project."
+"This email was sent to %(receiver_mail)s. This email was sent to you because"
+" you are a moderator in the project."
 msgstr ""
 
 #: apps/offlineevents/dashboard.py:13
@@ -2714,14 +2714,14 @@ msgid ""
 msgstr ""
 "U kunt algemene informatie over uw participatieplatform aan uw bezoekers "
 "verstrekken. Het is ook nuttig om een algemene contactpersoon te noemen voor"
-" vragen. De informatie wordt getoond op een aparte “Over” pagina die via het"
-" hoofdmenu te bereiken is."
+" vragen. De informatie wordt getoond op een aparte \"Over\" pagina die via "
+"het hoofdmenu te bereiken is."
 
 #: apps/organisations/models.py:113
 #: apps/organisations/templates/a4_candy_organisations/organisation_imprint.html:4
 #: apps/organisations/templates/a4_candy_organisations/organisation_imprint.html:10
 #: adhocracy-plus/templates/email_base.html:77
-#: adhocracy-plus/templates/email_base.html:104
+#: adhocracy-plus/templates/email_base.html:105
 #: adhocracy-plus/templates/footer.html:38
 #: adhocracy-plus/templates/footer_upper.html:16
 msgid "Imprint"
@@ -2740,8 +2740,7 @@ msgstr ""
 #: apps/organisations/templates/a4_candy_organisations/organisation_terms_of_use.html:10
 #: apps/users/forms.py:33 apps/users/forms.py:170
 #: adhocracy-plus/templates/email_base.html:81
-#: adhocracy-plus/templates/email_base.html:110
-#: adhocracy-plus/templates/email_base.txt:18
+#: adhocracy-plus/templates/email_base.html:111
 #: adhocracy-plus/templates/footer.html:43
 #: adhocracy-plus/templates/footer_upper.html:24
 msgid "Terms of use"
@@ -2756,7 +2755,7 @@ msgstr ""
 "gebruiksvoorwaarden worden op een aparte pagina weergegeven."
 
 #: apps/organisations/models.py:127
-#: adhocracy-plus/templates/email_base.html:107
+#: adhocracy-plus/templates/email_base.html:108
 #: adhocracy-plus/templates/footer.html:48
 #: adhocracy-plus/templates/footer_upper.html:20
 msgid "Data protection policy"
@@ -2847,7 +2846,7 @@ msgid ""
 "href=\"%(account_login_url)s?next=%(organisation_url)s\">here</a>."
 msgstr ""
 "Op dit moment zijn er geen publieke participatieprocessen. <a "
-"href=“%(account_login_url)s?next=%(organisation_url)s”>Log in</a>."
+"href=\"%(account_login_url)s?next=%(organisation_url)s\">Log in</a>."
 
 #: apps/organisations/views.py:28
 msgid "Participate now!"
@@ -2963,8 +2962,8 @@ msgstr ""
 #: apps/projects/templates/a4_candy_projects/emails/invite_moderator.en.email:14
 #, python-format
 msgid ""
-"This email was sent to %(receiver_mail)s. This email was sent to you because "
-"you are invited to moderate a project."
+"This email was sent to %(receiver_mail)s. This email was sent to you because"
+" you are invited to moderate a project."
 msgstr ""
 
 #: apps/projects/templates/a4_candy_projects/emails/invite_participant.en.email:4
@@ -2984,8 +2983,8 @@ msgstr ""
 #: apps/projects/templates/a4_candy_projects/emails/invite_participant.en.email:13
 #, python-format
 msgid ""
-"This email was sent to %(receiver_mail)s. This email was sent to you because "
-"you are invited to participate in a private project."
+"This email was sent to %(receiver_mail)s. This email was sent to you because"
+" you are invited to participate in a private project."
 msgstr ""
 
 #: apps/projects/templates/a4_candy_projects/includes/project_list_tile.html:37
@@ -3175,7 +3174,7 @@ msgstr "Project: %(project)s"
 #: apps/projects/templates/a4_candy_projects/participantinvite_detail.html:9
 #, python-format
 msgid "Invitation to participate in the project \"%(project)s\"?"
-msgstr "Uitnodiging tot deelname aan het project “%(project)s”?"
+msgstr "Uitnodiging tot deelname aan het project \"%(project)s\"?"
 
 #: apps/projects/templates/a4_candy_projects/participantinvite_detail.html:12
 msgid ""
@@ -3197,7 +3196,7 @@ msgid ""
 "                    "
 msgstr ""
 "\n"
-"                    U bent uitgenodigd door de initiatiefnemer van het project. Als u akkoord gaat, kunt u deelnemen aan het project met uw gebruikersnaam “%(user)s”.\n"
+"                    U bent uitgenodigd door de initiatiefnemer van het project. Als u akkoord gaat, kunt u deelnemen aan het project met uw gebruikersnaam \"%(user)s\".\n"
 "                    Als u met een ander profiel wilt meedoen, log dan in met uw andere profiel en volg de uitnodigingslink opnieuw. Als u de uitnodiging afslaat is de link niet meer geldig.\n"
 "                    "
 
@@ -3281,7 +3280,7 @@ msgstr "Deelnemer succesvol verwijderd."
 #: apps/projects/views.py:253
 #, python-format
 msgid "Project '%(name)s' was deleted successfully."
-msgstr "Project “%(name)s” werd met succes geschrapt."
+msgstr "Project \"%(name)s\" werd met succes geschrapt."
 
 #: apps/questions/models.py:44
 msgid "Question"
@@ -3469,7 +3468,7 @@ msgid ""
 msgstr ""
 "Er is al een deelnemer met dit lidmaatschapsnummer. Controleer uw "
 "inschrijving. Als dit uw lidmaatschapsnummer is, stuur dan een e-mail naar "
-"“zukunftsgewerkschaft@igbce.de”."
+"\"zukunftsgewerkschaft@igbce.de\"."
 
 #: apps/users/forms.py:131
 msgid ""
@@ -3480,7 +3479,7 @@ msgstr ""
 "Helaas kon het ledennummer en/of de geboortedatum niet worden gekoppeld aan "
 "een actief ledenaccount. Controleer uw invoer en probeer het opnieuw. Als u "
 "nog steeds problemen heeft, neem dan contact op met "
-"“zukunftsgewerkschaft@igbce.de”."
+"\"zukunftsgewerkschaft@igbce.de\"."
 
 #: apps/users/models.py:19
 msgid "username"
@@ -3585,7 +3584,6 @@ msgstr "Menu"
 
 #: apps/users/templates/a4_candy_users/indicator.html:26
 #: adhocracy-plus/templates/email_base.html:40
-#: adhocracy-plus/templates/email_base.txt:5
 msgid "Hello"
 msgstr "Hallo"
 
@@ -3794,21 +3792,25 @@ msgstr "Interne serverfout."
 msgid "Back to adhocracy+"
 msgstr "Terug naar adhocratie+"
 
-#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:22
+#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:17
+msgid "Home"
+msgstr ""
+
+#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:24
 msgid "Organisations"
 msgstr "Organisaties"
 
-#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:52
-#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:80
-#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:92
+#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:54
+#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:82
+#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:94
 #: adhocracy-plus/templates/a4dashboard/base_project_list.html:7
 #: adhocracy-plus/templates/a4dashboard/base_project_list.html:10
 msgid "Participation projects"
 msgstr "Participatie projecten"
 
-#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:62
-#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:84
-#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:104
+#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:64
+#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:86
+#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:106
 #: adhocracy-plus/templates/a4dashboard/organisation_form_base.html:7
 #: adhocracy-plus/templates/a4dashboard/organisation_form_base.html:10
 msgid "Organisation settings"
@@ -3828,23 +3830,23 @@ msgstr "Project klaar voor publicatie"
 msgid "Project not ready for publication"
 msgstr "Project niet klaar voor publicatie"
 
-#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:70
+#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:72
 msgid "Module ready for addition"
 msgstr "Module klaar om toe te voegen"
 
-#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:72
+#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:74
 msgid "Module not ready for addition"
 msgstr "Module niet klaar voor toevoeging"
 
-#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:101
+#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:103
 msgid "Hide from project"
 msgstr "Verberg je voor het project"
 
-#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:108
+#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:110
 msgid "Add to project"
 msgstr "Toevoegen aan project"
 
-#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:124
+#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:126
 msgid "Add Module"
 msgstr "Module toevoegen"
 
@@ -3879,7 +3881,7 @@ msgstr "verwijderen"
 #: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:82
 #, python-format
 msgid " Are you sure you want to delete the project '%(project_name)s'? "
-msgstr " Weet u zeker dat u het project “%(project_name)s” wilt verwijderen? "
+msgstr " Weet u zeker dat u het project \"%(project_name)s\" wilt verwijderen? "
 
 #: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:91
 msgid "cancel"
@@ -4035,7 +4037,8 @@ msgid ""
 "You have registered with the username \"%(username)s\" on the participation "
 "platform \"%(current_site)s\". Click \"Confirm email address\" to complete "
 "your registration. As soon as you are registered, you can participate on "
-"\"%(current_site)s\". If you haven't registered, you can ignore this message."
+"\"%(current_site)s\". If you haven't registered, you can ignore this "
+"message."
 msgstr ""
 
 #: adhocracy-plus/templates/account/email/email_confirmation_signup.en.email:11
@@ -4091,7 +4094,7 @@ msgid ""
 "            email address for user %(user_display)s."
 msgstr ""
 "AUB\n"
-"            bevestigen dat <a href=“mailto:%(email)s”>%(email)s</a> een\n"
+"            bevestigen dat <a href=\"mailto:%(email)s\">%(email)s</a> een\n"
 "            e-mailadres is voor gebruiker %(user_display)s."
 
 #: adhocracy-plus/templates/account/email_confirm.html:17
@@ -4201,7 +4204,7 @@ msgid ""
 "        <a href=\"%(login_url)s\">login</a>."
 msgstr ""
 "Heeft u al een account? Dan graag\n"
-"        <a href=\"%(login_url)s”>inloggen</a>."
+"        <a href=\"%(login_url)s\">inloggen</a>."
 
 #: adhocracy-plus/templates/account/signup.html:23
 #: adhocracy-plus/templates/socialaccount/signup.html:28
@@ -4252,8 +4255,7 @@ msgstr "Fout"
 msgid "Responsible for the participation project:"
 msgstr "Verantwoordelijk voor het participatieproject:"
 
-#: adhocracy-plus/templates/email_base.html:94
-#: adhocracy-plus/templates/email_base.txt:13
+#: adhocracy-plus/templates/email_base.html:95
 msgid "adhocracy+ is a participation platform operated by"
 msgstr "adhocracy+ is een participatieplatform dat wordt beheerd door"
 
@@ -4281,11 +4283,11 @@ msgstr "Verantwoordelijk voor de inhoud van deze pagina:"
 msgid "Header"
 msgstr "Kop"
 
-#: adhocracy-plus/templates/header_lower.html:25
+#: adhocracy-plus/templates/header_lower.html:27
 msgid "Our projects"
 msgstr "Onze projecten"
 
-#: adhocracy-plus/templates/header_lower.html:30
+#: adhocracy-plus/templates/header_lower.html:32
 msgid "About"
 msgstr "Over"
 
@@ -4350,6 +4352,11 @@ msgstr "Inloggen met social media account"
 #: adhocracy-plus/templates/socialaccount/snippets/provider_list.html:23
 msgid "Login with "
 msgstr "Inloggen met "
+
+#~ msgid "Module cannot be removed. It is the only module added to the project."
+#~ msgstr ""
+#~ "De module kan niet worden verwijderd. Het is de enige module die aan het "
+#~ "project is toegevoegd."
 
 #~ msgid "Responsible for the content of this e-mail:"
 #~ msgstr "Verantwoordelijk voor de inhoud van deze e-mail:"
@@ -4666,7 +4673,7 @@ msgstr "Inloggen met "
 #~ "                "
 #~ msgstr ""
 #~ "\n"
-#~ "                    U bent uitgenodigd door de initiatiefnemer van het project. Als u akkoord gaat, kunt u deelnemen aan het project met uw gebruikersnaam “%(user)s”.\n"
+#~ "                    U bent uitgenodigd door de initiatiefnemer van het project. Als u akkoord gaat, kunt u deelnemen aan het project met uw gebruikersnaam \"%(user)s\".\n"
 #~ "                    Als u met een ander profiel wilt meedoen, log dan in met uw andere profiel en volg de uitnodigingslink opnieuw. Als u de uitnodiging afslaat, is de link niet meer geldig.\n"
 #~ "                    "
 
@@ -5676,7 +5683,7 @@ msgstr "Inloggen met "
 #~ "            e-mail address for user %(user_display)s."
 #~ msgstr ""
 #~ "AUB\n"
-#~ "            bevestigen dat <a href=“mailto:%(email)s”>%(email)s</a> een\n"
+#~ "            bevestigen dat <a href=\"mailto:%(email)s\">%(email)s</a> een\n"
 #~ "            e-mailadres is voor gebruiker %(user_display)s."
 
 #~ msgid ""

--- a/locale/nl_NL/LC_MESSAGES/djangojs.po
+++ b/locale/nl_NL/LC_MESSAGES/djangojs.po
@@ -2,16 +2,16 @@
 # Copyright (C) YEAR THE PACKAGE'S COPYRIGHT HOLDER
 # This file is distributed under the same license as the PACKAGE package.
 # FIRST AUTHOR <EMAIL@ADDRESS>, YEAR.
-#
+# 
 # Translators:
 # Joop Laan <joop@interconnecting.systems>, 2020
-#
+# 
 #, fuzzy
 msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2020-05-20 13:50+0200\n"
+"POT-Creation-Date: 2020-07-17 16:07+0200\n"
 "PO-Revision-Date: 2020-06-26 14:15+0000\n"
 "Last-Translator: Joop Laan <joop@interconnecting.systems>, 2020\n"
 "Language-Team: Dutch (Netherlands) (https://www.transifex.com/liqd/teams/111081/nl_NL/)\n"
@@ -57,10 +57,12 @@ msgid "Answer"
 msgstr "Antwoorden"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:31
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:410
 msgid "Your reply here"
 msgstr "Uw reactie hier"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:32
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:279
 #: adhocracy4/reports/static/reports/react_reports.jsx:20
 msgid ""
 "You want to report this content? Your message will be sent to the "
@@ -72,29 +74,38 @@ msgstr ""
 " verwijderd als deze niet voldoet aan onze discussieregels (netiquette)."
 
 #: adhocracy4/comments/static/comments/Comment.jsx:96
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:256
 msgid "Moderator"
 msgstr "Moderator"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:105
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:251
 msgid "Latest edit on"
 msgstr "Laatste bewerking op"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:147
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:232
 msgid "Do you really want to delete this comment?"
 msgstr "Wilt u deze opmerking echt verwijderen?"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:148
 #: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:7
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:234
+#: adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx:22
 #: adhocracy4/polls/static/polls/QuestionForm.jsx:14
 #: apps/documents/assets/ChapterNavItem.jsx:56
 #: apps/documents/assets/ChapterNavItem.jsx:61
 #: apps/documents/assets/ParagraphForm.jsx:133
 #: apps/documents/assets/ParagraphForm.jsx:138
+#: apps/polls/assets/QuestionForm.jsx:99
+#: apps/polls/assets/QuestionForm.jsx:104
 msgid "Delete"
 msgstr "Verwijderen"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:149
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:235
 #: adhocracy4/comments_async/static/modals/modal.jsx:58
+#: adhocracy4/comments_async/static/modals/moderate_modal.jsx:54
 #: adhocracy4/static/Modal.jsx:59
 msgid "Abort"
 msgstr "Afbreken"
@@ -186,6 +197,14 @@ msgstr "reacties verbergen"
 msgctxt "verb"
 msgid "Comment"
 msgstr "Reageren"
+
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:286
+msgid "Share link"
+msgstr "Link delen"
+
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:325
+msgid "Categories: "
+msgstr "Categorieën: "
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:15
 msgid "Newest"
@@ -282,6 +301,10 @@ msgstr "Aanbevolen reactie"
 msgid "Is recommended"
 msgstr "Wordt aanbevolen"
 
+#: adhocracy4/comments_async/static/modals/moderate_modal.jsx:53
+msgid "Submit"
+msgstr "Versturen"
+
 #: adhocracy4/comments_async/static/modals/report_modal.jsx:62
 msgid ""
 "Thanks for the feedback. It will be checked by the moderators as soon as "
@@ -351,6 +374,7 @@ msgid "Save"
 msgstr "Bewaren"
 
 #: adhocracy4/polls/static/polls/Question.jsx:9
+#: apps/polls/assets/Question.jsx:172
 msgid "Your choice"
 msgstr "Uw keuze"
 
@@ -379,14 +403,17 @@ msgid "Please login to vote"
 msgstr "Log in om te stemmen"
 
 #: adhocracy4/polls/static/polls/Question.jsx:140
+#: apps/polls/assets/Question.jsx:137
 msgid "To poll"
 msgstr "Stemmen"
 
 #: adhocracy4/polls/static/polls/Question.jsx:142
+#: apps/polls/assets/Question.jsx:140
 msgid "Change vote"
 msgstr "Stem aanpassen"
 
 #: adhocracy4/polls/static/polls/Question.jsx:145
+#: apps/polls/assets/Question.jsx:144
 msgid "Show preliminary results"
 msgstr "Toon voorlopige resultaten"
 
@@ -408,6 +435,7 @@ msgid "Users can select more than one answer."
 msgstr "Gebruikers kunnen meer dan één antwoord selecteren."
 
 #: adhocracy4/polls/static/polls/QuestionForm.jsx:11
+#: apps/polls/assets/QuestionForm.jsx:67
 msgid "Add a new choice"
 msgstr "Nieuwe keuze toevoegen"
 
@@ -416,6 +444,7 @@ msgstr "Nieuwe keuze toevoegen"
 #: apps/documents/assets/ChapterNavItem.jsx:37
 #: apps/documents/assets/ParagraphForm.jsx:110
 #: apps/documents/assets/ParagraphForm.jsx:115
+#: apps/polls/assets/QuestionForm.jsx:76 apps/polls/assets/QuestionForm.jsx:81
 msgid "Move up"
 msgstr "Omhoog plaatsten"
 
@@ -424,6 +453,7 @@ msgstr "Omhoog plaatsten"
 #: apps/documents/assets/ChapterNavItem.jsx:49
 #: apps/documents/assets/ParagraphForm.jsx:122
 #: apps/documents/assets/ParagraphForm.jsx:127
+#: apps/polls/assets/QuestionForm.jsx:88 apps/polls/assets/QuestionForm.jsx:93
 msgid "Move down"
 msgstr "Omlaag plaatsen"
 
@@ -436,7 +466,8 @@ msgstr "Keuze"
 msgid "Thank you! We are taking care of it."
 msgstr "Dank u wel! We zorgen ervoor."
 
-#: adhocracy4/static/Alert.jsx:5 apps/dashboard/assets/ajax_modal.js:12
+#: adhocracy4/static/Alert.jsx:5 apps/contrib/assets/Alert.jsx:10
+#: apps/contrib/assets/Alert.jsx:11 apps/dashboard/assets/ajax_modal.js:12
 #: apps/embed/assets/embed.js:54 apps/embed/assets/embed.js:55
 #: apps/maps/assets/map_choose_polygon_with_preset.js:84
 msgid "Close"
@@ -707,15 +738,6 @@ msgid "If you leave this page changes you made will not be saved."
 msgstr ""
 "Als u deze pagina verlaat, worden de door u aangebrachte wijzigingen niet "
 "opgeslagen."
-
-#~ msgid "Share link"
-#~ msgstr "Link delen"
-
-#~ msgid "Categories: "
-#~ msgstr "Categorieën: "
-
-#~ msgid "Submit"
-#~ msgstr "Versturen"
 
 #~ msgid "The maximal length of your contribution is 4000 characters"
 #~ msgstr "De maximale lengte van uw bijdrage is 4000 tekens"


### PR DESCRIPTION
fixes  #708

The problem was, that in the dutch translations  ” (left/right double quotaton marks) were used instead of ". Transifex doesnt escape them and thus the links are broken..so this is some kind of unicode thing?

We should think about a way to prevent this.