### PR TITLE
requirements: update isort to 5.2.3, travis.yml: update travis config to be inline with other projects

### DIFF
--- a/.polylintrc
+++ b/.polylintrc
@@ -1,4 +1,0 @@
-py:flake8 --exclude */migrations/*,*/settings/* %s
-py:isort --diff -c
-scss:node_modules/.bin/stylelint --syntax scss %s
-js\\|jsx:node_modules/.bin/eslint -c .eslintrc --ext js,jsx %s

--- a/.polylintrc
+++ b/.polylintrc
@@ -1,4 +1,4 @@
 py:flake8 --exclude */migrations/*,*/settings/* %s
-py:isort --diff -rc -c
+py:isort --diff -c
 scss:node_modules/.bin/stylelint --syntax scss %s
 js\\|jsx:node_modules/.bin/eslint -c .eslintrc --ext js,jsx %s

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,9 @@ script:
 - python manage.py collectstatic > /dev/null
 - py.test --cov
 - python manage.py makemigrations --dry-run --check --noinput
-- "./node_modules/.bin/polylint -F"
+- isort --diff -rc -c adhocracy-plus tests
+- flake8 adhocracy-plus tests --exclude migrations,settings
+- npm run lint
 - rm -rf static/
 after_success:
 - coveralls

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ before_script:
 - psql -c 'create database django_test;' -U postgres
 script:
 - python manage.py collectstatic > /dev/null
-- py.test --cov
+- py.test --cov --nomigrations
 - python manage.py makemigrations --dry-run --check --noinput
 - isort --diff -rc -c adhocracy-plus tests
 - flake8 adhocracy-plus tests --exclude migrations,settings

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ coverage:
 .PHONY: lint
 lint:
 	EXIT_STATUS=0; \
-	$(VIRTUAL_ENV)/bin/isort --diff -rc -c $(SOURCE_DIRS) || EXIT_STATUS=$$?; \
+	$(VIRTUAL_ENV)/bin/isort -c adhocracy-plus apps --diff ||  EXIT_STATUS=$$?; \
 	$(VIRTUAL_ENV)/bin/flake8 $(SOURCE_DIRS) --exclude migrations,settings ||  EXIT_STATUS=$$?; \
 	npm run lint ||  EXIT_STATUS=$$?; \
 	$(VIRTUAL_ENV)/bin/python manage.py makemigrations --dry-run --check --noinput || EXIT_STATUS=$$?; \

--- a/Makefile
+++ b/Makefile
@@ -89,14 +89,16 @@ coverage:
 .PHONY: lint
 lint:
 	EXIT_STATUS=0; \
-	. $(VIRTUAL_ENV)/bin/activate && $(NODE_BIN)/polylint || EXIT_STATUS=$$?; \
+	$(VIRTUAL_ENV)/bin/isort --diff -rc -c $(SOURCE_DIRS) || EXIT_STATUS=$$?; \
+	$(VIRTUAL_ENV)/bin/flake8 $(SOURCE_DIRS) --exclude migrations,settings ||  EXIT_STATUS=$$?; \
+	npm run lint ||  EXIT_STATUS=$$?; \
 	$(VIRTUAL_ENV)/bin/python manage.py makemigrations --dry-run --check --noinput || EXIT_STATUS=$$?; \
 	exit $${EXIT_STATUS}
 
 .PHONY: lint-quick
 lint-quick:
 	EXIT_STATUS=0; \
-	. $(VIRTUAL_ENV)/bin/activate && $(NODE_BIN)/polylint -SF || EXIT_STATUS=$$?; \
+	npm run lint-staged ||  EXIT_STATUS=$$?; \
 	$(VIRTUAL_ENV)/bin/python manage.py makemigrations --dry-run --check --noinput || EXIT_STATUS=$$?; \
 	exit $${EXIT_STATUS}
 

--- a/package.json
+++ b/package.json
@@ -77,7 +77,8 @@
   "scripts": {
     "build:prod": "webpack --config webpack.prod.js --mode production",
     "build": "webpack --config webpack.dev.js --mode development",
-    "watch": "webpack --config webpack.dev.js --watch --mode development"
+    "watch": "webpack --config webpack.dev.js --watch --mode development",
+    "lint": "eslint apps adhocracy-plus/assets --ext .js,.jsx && stylelint 'adhocracy-plus/assets/scss/**/*.scss' --syntax scss"
   },
   "browserslist": "defaults and not dead and >= 0.5%, ie >= 11",
   "husky": {

--- a/package.json
+++ b/package.json
@@ -67,8 +67,8 @@
     "eslint-plugin-react": "7.20.5",
     "eslint-plugin-standard": "4.0.1",
     "husky": "4.2.5",
+    "lint-staged": "10.2.11",
     "markdownlint-cli": "0.23.2",
-    "polylint.sh": "0.0.4",
     "stylelint": "13.6.1",
     "stylelint-config-standard": "20.0.0",
     "stylelint-declaration-strict-value": "1.5.0",
@@ -78,12 +78,18 @@
     "build:prod": "webpack --config webpack.prod.js --mode production",
     "build": "webpack --config webpack.dev.js --mode development",
     "watch": "webpack --config webpack.dev.js --watch --mode development",
-    "lint": "eslint apps adhocracy-plus/assets --ext .js,.jsx && stylelint 'adhocracy-plus/assets/scss/**/*.scss' --syntax scss"
+    "lint": "eslint apps adhocracy-plus/assets --ext .js,.jsx && stylelint 'adhocracy-plus/assets/scss/**/*.scss' --syntax scss",
+    "lint-staged": "lint-staged"
   },
   "browserslist": "defaults and not dead and >= 0.5%, ie >= 11",
   "husky": {
     "hooks": {
       "pre-commit": "make lint-quick"
     }
+  },
+  "lint-staged": {
+      "adhocracy-plus/assets/js/*.{js,jsx}": ["eslint"],
+      "apps/**/*.{js,jsx}": ["eslint"],
+      "adhocracy-plus/assets/scss/**/*.scss": ["stylelint"]
   }
 }

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -5,7 +5,7 @@ Faker==4.1.1
 flake8-docstrings==1.5.0
 flake8==3.8.3
 freezegun==0.3.15
-isort==5.2.0
+isort==5.3.2
 pytest-cov==2.10.0
 pytest-django==3.9.0
 pytest-factoryboy==2.0.3


### PR DESCRIPTION
Ok what I think is happening is:
Lint script has been moved to package.json so it can run make lint.
A script to run the lint-staged config has been added and this is called in make lint-quick. Pre-commit calls make lint-quick which runs the lint-staged config on required files