### PR TITLE
docs: Some additions to shibboleth config

### DIFF
--- a/docs/installation_prod.md
+++ b/docs/installation_prod.md
@@ -332,6 +332,7 @@ import saml2.saml
 BASEDIR = path.dirname(path.abspath(__file__))
 
 SAML_CONFIG = {
+  'xmlsec_binary': '/usr/bin/xmlsec1',
   'entityid': 'https://your.domain/saml2/metadata/',
   'allow_unknown_attributes': True,
   'attribute_map_dir': path.join(BASEDIR, 'attribute-maps'),
@@ -377,7 +378,7 @@ In the `settings` folder, where your `local.py` resides, create a new key and ce
 ```
 mkdir saml
 cd saml
-openssl req -x509 -newkey rsa:4096 -keyout private.key -out cert.pem -days 365
+openssl req -x509 -nodes -newkey rsa:4096 -keyout private.key -out cert.pem -days 365
 ```
 
 ### Registering


### PR DESCRIPTION
- xmlsec path must be set for djangosaml2 to work
- nodes disables key password protection, which is not helpful in
this scenario