### PR TITLE
diid: Add a default_idp setting

### DIFF
--- a/adhocracy-plus/templates/account/diid/saml2.html
+++ b/adhocracy-plus/templates/account/diid/saml2.html
@@ -6,7 +6,8 @@
     <div class="col pb-4">
         <a title="{% trans 'Login with HHU' %}"
            class="btn btn--primary {% if not saml_config %}disabled{% endif %}"
-           href="/saml2/login/?next={{ redirect_field_value }}">
+           href="/saml2/login/?{% if saml_config.default_idp %}idp={{ saml_config.default_idp }}&{% endif %}next={{ redirect_field_value }}"
+        >
            {% trans 'Login with ' %}<span class="u-hhu">hhu.</span>
        </a>
     </div>

--- a/docs/installation_prod.md
+++ b/docs/installation_prod.md
@@ -354,11 +354,9 @@ SAML_CONFIG = {
     },
   },
   'metadata': {
-    # Only use the HHU IDP
-    'remote': [{"url": "https://idp.uni-duesseldorf.de/idp/shibboleth"},],
-    # Allow all members of in the DNF - comment out the remote above if used
-    #'remote': [{"url": "https://www.aai.dfn.de/fileadmin/metadata/dfn-aai-test-metadata.xml"},],
+    'remote': [{"url": "https://www.aai.dfn.de/fileadmin/metadata/dfn-aai-test-metadata.xml"},],
   },
+  'default_idp': "https://idp-test.uni-duesseldorf.de/idp/shibboleth",
   'key_file': path.join(BASEDIR, 'saml', 'private.key'),  # private part
   'cert_file': path.join(BASEDIR, 'saml', 'cert.pem'),  # public part
   'encryption_keypairs': [{


### PR DESCRIPTION
When set, the login directly forwards to the specified IDP, in
contrast to showing a full list. This does not prevent other IPDs
to send valid login tokens - thus the user needs to make sure the
own service is only registered on the desired IDP.