### PR TITLE
config/dev: Do not require xmlsec1 to be installed

### DIFF
--- a/adhocracy-plus/config/settings/dev.py
+++ b/adhocracy-plus/config/settings/dev.py
@@ -42,7 +42,6 @@ import saml2.saml
 BASEDIR = path.dirname(path.abspath(__file__))
 
 SAML_CONFIG = {
-  'xmlsec_binary': '/usr/bin/xmlsec1',
   'entityid': 'http://app.example.com',
   'allow_unknown_attributes': True,
   'attribute_map_dir': path.join(BASEDIR, 'saml', 'attribute-maps'),


### PR DESCRIPTION
It's important to have for prod instances, but for dev it apparently
works regardless.