### PR TITLE
Makefile: Merge po-fork back into po

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,14 +118,9 @@ po:
 	$(VIRTUAL_ENV)/bin/python manage.py makemessages -d django --extension html,email,py
 	$(VIRTUAL_ENV)/bin/python manage.py makemessages -d djangojs
 	$(SED) -i 's%#: .*/adhocracy4%#: adhocracy4%' locale-source/locale/*/LC_MESSAGES/django*.po
+	$(SED) -i 's%#: .*/adhocracy4%#: adhocracy4%' locale-fork/locale/*/LC_MESSAGES/django*.po
 	msgen locale-source/locale/en_GB/LC_MESSAGES/django.po -o locale-source/locale/en_GB/LC_MESSAGES/django.po
 	msgen locale-source/locale/en_GB/LC_MESSAGES/djangojs.po -o locale-source/locale/en_GB/LC_MESSAGES/djangojs.po
-
-.PHONY: po-fork
-po-fork:
-	$(VIRTUAL_ENV)/bin/python manage.py makemessages -d django --extension html,email,py
-	$(VIRTUAL_ENV)/bin/python manage.py makemessages -d djangojs
-	$(SED) -i 's%#: .*/adhocracy4%#: adhocracy4%' locale-fork/locale/*/LC_MESSAGES/django*.po
 
 .PHONY: mo
 mo:

--- a/docs/translations.md
+++ b/docs/translations.md
@@ -29,7 +29,7 @@ To create the new translations, go to the
 [base settings](https://github.com/liqd/adhocracy-plus/blob/master/adhocracy-plus/config/settings/base.py)
 and uncomment the first path
 (os.path.join(BASE_DIR, 'locale-fork/locale')) in LOCALE_PATHS.
-Now, `make po-fork` creates message files in the locale-fork folder and
+Now, `make po` creates message files in the locale-fork folder and
 uses the translations from this folder first, whenever the messages are
 compiled.
 Here, the English translations are kept untranslated, so that they could


### PR DESCRIPTION
Appently they behave mutually exclusive anyway - if `po-fork` should be
used, `po` produces broken output.

@fuzzylogic2000 does that look sensible to you?