### PR TITLE
docs: Add --upgrade to pip install

### DIFF
--- a/docs/installation_prod.md
+++ b/docs/installation_prod.md
@@ -285,7 +285,7 @@ rm -rf static/*
 ```
 npm install
 npm run build:prod
-pip install -r requirements.txt
+pip install --upgrade -r requirements.txt
 export DJANGO_SETTINGS_MODULE=adhocracy-plus.config.settings.build
 python manage.py compilemessages
 python manage.py collectstatic


### PR DESCRIPTION
Otherwise a4 will not get updated, resulting in errors afterwards.
This could be fixed by turning a4 into a propper package with
versions.