### PR TITLE
apps/organisations: make module still be shown when organisation does…

### DIFF
--- a/adhocracy-plus/templates/header_lower.html
+++ b/adhocracy-plus/templates/header_lower.html
@@ -5,12 +5,12 @@
     <div class="col-md-10 offset-md-1">
         <nav class="header-lower__nav">
 
-            {% if ORGANISATION.logo %}
+            {% if ORGANISATION and ORGANISATION.logo %}
               {% url 'organisation' organisation_slug=ORGANISATION.slug as organisation_url %}
                 <a href="{% url 'organisation' organisation_slug=ORGANISATION.slug %}" class="header-lower__logo-box" rel="home">
                     <img src="{% thumbnail ORGANISATION.logo '0x160' %}" height="80" alt="{{ ORGANISATION.name }}" class="header-lower__logo-img" />
                 </a>
-            {% else %}
+            {% elif ORGANISATION %}
               <div class="header-lower__brand u-bg-body">
                 <a class="font-weight-bold" href="{% url 'organisation' organisation_slug=ORGANISATION.slug %}">
                     {{ ORGANISATION.name }}
@@ -18,21 +18,23 @@
               </div>
             {% endif %}
 
-            {% url 'organisation' organisation_slug=ORGANISATION.slug as organisation_url %}
+            {% if ORGANISATION %}
+                {% url 'organisation' organisation_slug=ORGANISATION.slug as organisation_url %}
 
-            {% if request.get_full_path == organisation_url or '/information' in request.get_full_path %}
-                <ul class="header-lower__nav-list">
-                    <li class="header-lower__nav-item">
-                        {% url 'organisation' organisation_slug=ORGANISATION.slug as organisation_url %}
-                        <a href="{{ organisation_url }}" class="header-lower__nav-link"><span class="{% if request.path == organisation_url %}is-active{% endif %}">{% trans 'Our projects' %}</span></a>
-                    </li>
-                    {% if ORGANISATION.information %}
-                    <li class="header-lower__nav-item">
-                        {% url 'organisation-information' organisation_slug=ORGANISATION.slug as organisation_information_url %}
-                        <a href="{{ organisation_information_url }}" class="header-lower__nav-link"><span class="{% if request.path == organisation_information_url %}is-active{% endif %}">{% trans 'About' %}</span></a>
-                    </li>
-                    {% endif %}
-                </ul>
+                {% if request.get_full_path == organisation_url or '/information' in request.get_full_path %}
+                    <ul class="header-lower__nav-list">
+                        <li class="header-lower__nav-item">
+                            {% url 'organisation' organisation_slug=ORGANISATION.slug as organisation_url %}
+                            <a href="{{ organisation_url }}" class="header-lower__nav-link"><span class="{% if request.path == organisation_url %}is-active{% endif %}">{% trans 'Our projects' %}</span></a>
+                        </li>
+                        {% if ORGANISATION.information %}
+                        <li class="header-lower__nav-item">
+                            {% url 'organisation-information' organisation_slug=ORGANISATION.slug as organisation_information_url %}
+                            <a href="{{ organisation_information_url }}" class="header-lower__nav-link"><span class="{% if request.path == organisation_information_url %}is-active{% endif %}">{% trans 'About' %}</span></a>
+                        </li>
+                        {% endif %}
+                    </ul>
+                {% endif %}
             {% endif %}
         </nav>
     </div>


### PR DESCRIPTION
… not exist
fixes https://sentry.liqd.net/sentry/aplus-prod/issues/1092/ and https://sentry.liqd.net/sentry/aplus-dev/issues/1197/

This happens whenever a module view is accessed with a wrong organisation slug in the url. As a solution, the organisation info is now not shown. I think a 404 would be better, but don't know how to achieve that and think this is fine, as it very seldomly happens or shouldn't happen. (On dev it's quite clear what happened, but on prod, it's a bit weird as the organisation just doesn't exist.)