### PR TITLE
apps/organisations: make sure published poll in unpublished project d…

### DIFF
--- a/apps/organisations/templatetags/organisation_tags.py
+++ b/apps/organisations/templatetags/organisation_tags.py
@@ -9,11 +9,11 @@ register = template.Library()
 
 @register.simple_tag(takes_context=True)
 def get_current_organisation(context):
-    request = context.request
     try:
+        request = context.request
         resolver = resolve(request.path_info)
         if resolver.kwargs and 'organisation_slug' in resolver.kwargs:
             return Organisation.objects.get(
                 slug=resolver.kwargs['organisation_slug'])
-    except (Resolver404, Organisation.DoesNotExist):
+    except (Resolver404, Organisation.DoesNotExist, AttributeError):
         pass


### PR DESCRIPTION
…oesn't break the organisation_tags

another thing that shouldn't happen, but did: if a project has a poll that is not finished added, the preview breaks: https://aplus-stage.liqd.net/liqd/dashboard/projects/this-is-a-poll/basic/

fixes https://sentry.liqd.net/sentry/aplus-prod/issues/1001/events/latest/ and https://sentry.liqd.net/sentry/aplus-stage/issues/1090/?query=is%3Aunresolved