### PR TITLE
translations: Show languages in their own language

### DIFF
--- a/locale-source/locale/de/LC_MESSAGES/django.po
+++ b/locale-source/locale/de/LC_MESSAGES/django.po
@@ -3867,7 +3867,7 @@ msgstr "Noch keine Aktivität."
 
 #: adhocracy-plus/config/settings/base.py:199
 msgid "English"
-msgstr "Englisch"
+msgstr "English"
 
 #: adhocracy-plus/config/settings/base.py:200
 msgid "German"
@@ -3875,7 +3875,7 @@ msgstr "Deutsch"
 
 #: adhocracy-plus/config/settings/base.py:201
 msgid "Dutch"
-msgstr "Niederländisch"
+msgstr "Nederlands"
 
 #: adhocracy-plus/config/settings/base.py:408
 msgid "suggestion"

--- a/locale-source/locale/en/LC_MESSAGES/django.po
+++ b/locale-source/locale/en/LC_MESSAGES/django.po
@@ -3762,11 +3762,11 @@ msgstr "English"
 
 #: adhocracy-plus/config/settings/base.py:200
 msgid "German"
-msgstr "German"
+msgstr "Deutsch"
 
 #: adhocracy-plus/config/settings/base.py:201
 msgid "Dutch"
-msgstr "Dutch"
+msgstr "Nederlands"
 
 #: adhocracy-plus/config/settings/base.py:408
 msgid "suggestion"

--- a/locale-source/locale/nl/LC_MESSAGES/django.po
+++ b/locale-source/locale/nl/LC_MESSAGES/django.po
@@ -3835,11 +3835,11 @@ msgstr "Nog geen activiteit. "
 
 #: adhocracy-plus/config/settings/base.py:199
 msgid "English"
-msgstr "Engels"
+msgstr "English"
 
 #: adhocracy-plus/config/settings/base.py:200
 msgid "German"
-msgstr "Duits"
+msgstr "Deutsch"
 
 #: adhocracy-plus/config/settings/base.py:201
 msgid "Dutch"

--- a/locale-source/locale/tr/LC_MESSAGES/django.po
+++ b/locale-source/locale/tr/LC_MESSAGES/django.po
@@ -3564,15 +3564,15 @@ msgstr ""
 
 #: adhocracy-plus/config/settings/base.py:199
 msgid "English"
-msgstr ""
+msgstr "English"
 
 #: adhocracy-plus/config/settings/base.py:200
 msgid "German"
-msgstr ""
+msgstr "Deutsch"
 
 #: adhocracy-plus/config/settings/base.py:201
 msgid "Dutch"
-msgstr ""
+msgstr "Nederlands"
 
 #: adhocracy-plus/config/settings/base.py:408
 msgid "suggestion"


### PR DESCRIPTION
It's likely that someone looking to change the language doesn't know how the own language is called on another language. Always show languages in their own language in the language switcher.

![image](https://user-images.githubusercontent.com/6313774/98936005-a556ba80-24e4-11eb-85a7-ffa285ce78e0.png)


Depends on and includes #940 