### PR TITLE
adds/djangosaml2_overwrites: Add a middleware to guard saml signup

### DIFF
--- a/adhocracy-plus/config/settings/base.py
+++ b/adhocracy-plus/config/settings/base.py
@@ -136,6 +136,7 @@ MIDDLEWARE = (
     'apps.embed.middleware.AjaxPathMiddleware',
     'wagtail.core.middleware.SiteMiddleware',
     'wagtail.contrib.redirects.middleware.RedirectMiddleware',
+    'apps.djangosaml2_overwrites.middlewares.SamlSignupMiddleware',
 )
 
 ROOT_URLCONF = 'adhocracy-plus.config.urls'

--- a/apps/djangosaml2_overwrites/middlewares.py
+++ b/apps/djangosaml2_overwrites/middlewares.py
@@ -1,0 +1,33 @@
+from allauth.account.models import EmailAddress
+from django.shortcuts import redirect
+from django.urls import reverse
+
+
+class SamlSignupMiddleware:
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        response = self.get_response(request)
+        return response
+
+    def process_view(self, request, view_func, view_args, view_kwargs):
+        if request.user.is_authenticated:
+            email = EmailAddress.objects.get(user=request.user,
+                                             email=request.user.email)
+            if not email.verified:
+                path = request.path
+                view = request.resolver_match.view_name
+
+                allowed_paths = [
+                    reverse('saml2_signup'),
+                    reverse('saml2_logout'),
+                    reverse('set_language'),
+                    reverse('javascript-catalog')
+                ]
+                allowed_views = [
+                    'wagtail_serve'
+                ]
+
+                if path not in allowed_paths and view not in allowed_views:
+                    return redirect(reverse('saml2_signup') + "?next=" + path)


### PR DESCRIPTION
djangosaml2 does not offer a way to not login the user before doing
extra validation steps. In order to force users to sign up before
being able to use the website, add a simple middleware, redirecting
them to the signup as long as their email is not verified.

Logout and wagtail pages are excepted from these rules.