### PR TITLE
assets/scss/a4-comments: Styled by dev

### DIFF
--- a/adhocracy-plus/assets/scss/components/_a4-comments.scss
+++ b/adhocracy-plus/assets/scss/components/_a4-comments.scss
@@ -83,8 +83,6 @@
 
 .a4-comments__action-bar {
     padding: 0.5*$spacer 0;
-    display: contents;
-    justify-content: space-between;
 }
 
 .a4-comments__action-bar__btn {

--- a/adhocracy-plus/assets/scss/components/_a4-comments.scss
+++ b/adhocracy-plus/assets/scss/components/_a4-comments.scss
@@ -97,6 +97,7 @@
 
 .a4-comments__text,
 .a4-comments__author {
+    margin: 1.2*$spacer 0 1.2*$spacer 0;
     overflow-wrap: break-word;
     white-space: pre-wrap;
 }


### PR DESCRIPTION
Some small adjustments that IMO make things more pleasant to look at - but should be checked by designers/ux

Before:
![Screenshot_2020-11-17 adhocracy+ liqd-orga2](https://user-images.githubusercontent.com/6313774/99426261-2a3a3d80-2904-11eb-8dc1-c1c165fd25fc.png)

After:
![Screenshot_2020-11-17 adhocracy+ liqd-orga](https://user-images.githubusercontent.com/6313774/99426257-29a1a700-2904-11eb-93b5-49637b9b870b.png)
