### PR TITLE
settings: skip migrations for isort in lint-python-files

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -17,5 +17,6 @@ indent_style = tab
 # isort configuration
 [*.py]
 skip=migrations,node_modules,venv
+skip_glob = */migrations/*.py
 known_first_party=adhocracy4, adhocracy-plus, meinberlin, tests
 force_single_line = true

--- a/Makefile
+++ b/Makefile
@@ -109,7 +109,7 @@ lint-quick:
 .PHONY: lint-python-files
 lint-python-files:
 	EXIT_STATUS=0; \
-	$(VIRTUAL_ENV)/bin/isort --df -c $(ARGUMENTS) || EXIT_STATUS=$$?; \
+	$(VIRTUAL_ENV)/bin/isort --diff -c $(ARGUMENTS) --filter-files || EXIT_STATUS=$$?; \
 	$(VIRTUAL_ENV)/bin/flake8 $(ARGUMENTS) || EXIT_STATUS=$$?; \
 	exit $${EXIT_STATUS}
 


### PR DESCRIPTION
See https://github.com/liqd/a4-meinberlin/commit/efee8c04caa850b2326eb64fb8badece45bacde9