### PR TITLE
Revert "Update dependency leaflet to v1.7.1"

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "glob": "7.1.6",
     "immutability-helper": "3.1.1",
     "jquery": "3.5.1",
-    "leaflet": "1.7.1",
+    "leaflet": "1.6.0",
     "leaflet-draw": "1.0.4",
     "leaflet.markercluster": "git+https://github.com/liqd/Leaflet.markercluster#5ed89b26922c51083fc9632a2c01425b9261a0f5",
     "mapbox-gl": "1.13.0",


### PR DESCRIPTION
Reverts liqd/adhocracy-plus#920

Fix maps on safari fixes #987
workaround but just wait for next release? 
Issues:
https://github.com/Leaflet/Leaflet/issues/7331
https://github.com/Leaflet/Leaflet/issues/7255