### PR TITLE
apps/interactive_events: Restart polling interval when adding question

### DIFF
--- a/apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_box.jsx
+++ b/apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_box.jsx
@@ -11,6 +11,8 @@ export default class QuestionBox extends React.Component {
   constructor (props) {
     super(props)
 
+    this.restartPolling = this.restartPolling.bind(this)
+
     this.state = {
       questions: [],
       filteredQuestions: [],
@@ -27,8 +29,7 @@ export default class QuestionBox extends React.Component {
   }
 
   componentDidMount () {
-    this.getItems()
-    this.timer = setInterval(() => this.getItems(), 5000)
+    this.restartPolling()
   }
 
   componentWillUnmount () {
@@ -160,6 +161,12 @@ export default class QuestionBox extends React.Component {
     })
   }
 
+  restartPolling () {
+    this.getItems()
+    clearInterval(this.timer)
+    this.timer = setInterval(() => this.getItems(), 5000)
+  }
+
   render () {
     return (
       <div>
@@ -228,6 +235,7 @@ export default class QuestionBox extends React.Component {
               <div className="row mb-5">
                 <div className="col-md-10 offset-md-1">
                   <QuestionForm
+                    restartPolling={this.restartPolling}
                     category_dict={this.props.category_dict}
                     questions_api_url={this.props.questions_api_url}
                     privatePolicyLabel={this.props.privatePolicyLabel}

--- a/apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_form.jsx
+++ b/apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_form.jsx
@@ -50,6 +50,7 @@ export default class QuestionForm extends React.Component {
       questionCharCount: 0
     })
     anchor.scrollIntoView({ behavior: 'smooth', block: 'end' })
+    this.props.restartPolling()
   }
 
   render () {


### PR DESCRIPTION
Directly fire a update request and reset the timer, so the own question
is shown faster.