### PR TITLE
interactiveevents/assets: Use state instead of props again for list

### DIFF
--- a/apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_statistics_box.jsx
+++ b/apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_statistics_box.jsx
@@ -71,7 +71,7 @@ export default class StatisticsBox extends React.Component {
         {this.props.isModerator
           ? (
             <div className="list-group mt-md-4">
-              {this.props.answeredQuestions.map((question, index) => {
+              {this.state.answeredQuestions.map((question, index) => {
                 return (
                   <QuestionModerator
                     updateQuestion={this.updateQuestion.bind(this)}
@@ -97,7 +97,7 @@ export default class StatisticsBox extends React.Component {
           )
           : (
             <div className="list-group mt-3 mt-md-4">
-              {this.props.answeredQuestions.map((question, index) => {
+              {this.state.answeredQuestions.map((question, index) => {
                 return (
                   <QuestionUser
                     key={question.id}


### PR DESCRIPTION
So do actually take advatage of having the state.