### PR TITLE
apps/embed: Some 3rd-party cookie fixes

### DIFF
--- a/adhocracy-plus/config/settings/base.py
+++ b/adhocracy-plus/config/settings/base.py
@@ -120,6 +120,7 @@ INSTALLED_APPS = (
 
 MIDDLEWARE = (
     'django.middleware.security.SecurityMiddleware',
+    'django_samesite_none.middleware.SameSiteNoneMiddleware',
     'whitenoise.middleware.WhiteNoiseMiddleware',
     'django.middleware.csrf.CsrfViewMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',

--- a/apps/embed/assets/embed.js
+++ b/apps/embed/assets/embed.js
@@ -40,10 +40,8 @@ $(document).ready(function () {
   }
 
   var testCanSetCookie = function () {
-    var cookie = 'can-set-cookie=true;'
-    var regExp = new RegExp(cookie)
-    document.cookie = cookie
-    return regExp.test(document.cookie)
+    document.cookie = 'can-set-cookie=true;SameSite=None;Secure'
+    return document.cookie.indexOf('can-set-cookie=') !== -1
   }
 
   var createAlert = function (text, state, timeout) {

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -14,6 +14,9 @@ whitenoise==5.2.0
 xmltodict==0.12.0
 zeep==4.0.0
 
+# Obsolete in Django >= 3.1
+django-samesite-none==0.0.3
+
 # Inherited a4-core requirements
 bleach==3.2.1
 Django==2.2.17 # pyup: <2.3


### PR DESCRIPTION
The cookie test was completely broken, not sure why that should have worked in the past. And a workaround for https://code.djangoproject.com/ticket/31933