### PR TITLE
Ks 2021 02 update js

### DIFF
--- a/adhocracy-plus/assets/js/app.js
+++ b/adhocracy-plus/assets/js/app.js
@@ -13,7 +13,7 @@ import '../../../apps/newsletters/assets/dynamic_fields.js'
 // expose react components
 import {
   comments as ReactComments,
-  comments_async as ReactCommentsAsync,
+  commentsAsync as ReactCommentsAsync,
   ratings as ReactRatings,
   reports as ReactReports,
   follows as ReactFollows,

--- a/apps/maps/assets/map-address.js
+++ b/apps/maps/assets/map-address.js
@@ -69,8 +69,6 @@ var setBusy = function ($group, busy) {
 }
 
 var getPoints = function (address, cb) {
-  var $ = window.jQuery
-
   $.ajax(apiUrl, {
     data: { address: address },
     success: function (geojson) {

--- a/apps/maps/assets/map_choose_polygon_with_preset.js
+++ b/apps/maps/assets/map_choose_polygon_with_preset.js
@@ -2,7 +2,7 @@
 
 /* global django */
 import 'bootstrap' // needed for $(...).modal(...)
-import { createMap } from 'a4maps_common'
+import { maps } from 'adhocracy4'
 import 'leaflet-draw'
 import './i18n-leaflet-draw'
 import FileSaver from 'file-saver'
@@ -184,7 +184,7 @@ function init () {
     const polygon = JSON.parse(e.getAttribute('data-polygon'))
     const bbox = JSON.parse(e.getAttribute('data-bbox'))
 
-    const map = createMap(L, e, {
+    const map = maps.createMap(L, e, {
       baseUrl: e.getAttribute('data-baseurl'),
       useVectorMap: e.getAttribute('data-usevectormap'),
       attribution: e.getAttribute('data-attribution'),

--- a/apps/maps/assets/map_choose_polygon_with_preset.js
+++ b/apps/maps/assets/map_choose_polygon_with_preset.js
@@ -1,7 +1,6 @@
 /* Adds extra select dropdown to choose predefined polygon instead of drawing one */
 
 /* global django */
-import 'bootstrap' // needed for $(...).modal(...)
 import { maps } from 'adhocracy4'
 import 'leaflet-draw'
 import './i18n-leaflet-draw'
@@ -20,6 +19,7 @@ function getBaseBounds (L, polygon, bbox) {
 }
 
 function init () {
+  const $ = window.$
   const L = window.L
 
   const ImportControl = L.Control.extend({

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@babel/runtime": "7.12.13",
     "@fortawesome/fontawesome-free": "5.15.2",
     "acorn": "8.0.5",
-    "adhocracy4": "git+https://github.com/liqd/adhocracy4#aplus-v2012.2",
+    "adhocracy4": "git+https://github.com/liqd/adhocracy4#4f8efd0822a424787138ac8e51d8740d4c2849a8",
     "autoprefixer": "10.2.4",
     "axios": "0.21.1",
     "babel-loader": "8.2.2",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+https://github.com/liqd/adhocracy4.git@aplus-v2012.2#egg=adhocracy4
+git+https://github.com/liqd/adhocracy4.git@4f8efd0822a424787138ac8e51d8740d4c2849a8#egg=adhocracy4
 
 # Additional requirements
 bcrypt==3.2.0

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -138,7 +138,6 @@ module.exports = {
     fallback: { path: require.resolve('path-browserify') },
     extensions: ['*', '.js', '.jsx', '.scss', '.css'],
     alias: {
-      a4maps_common$: 'adhocracy4/adhocracy4/maps/static/a4maps/a4maps_common.js',
       bootstrap$: 'bootstrap/dist/js/bootstrap.bundle.min.js',
       'file-saver': 'file-saver/dist/FileSaver.min.js',
       jquery$: 'jquery/dist/jquery.min.js',


### PR DESCRIPTION
So I tried to find all that needed adjustment when updating A4 after the js refactoring.

I initially wanted to port over [this PR](https://github.com/liqd/a4-meinberlin/pull/3386/files) from mB, but realized that we dont need that here, as we dont have plans and the other map initialization is done in A4, right?

Also not sure about [this PR]([url](https://github.com/liqd/a4-meinberlin/pull/3387/files))? The jQuery wasnt there before and I didnt add it, because polygons seem to work fine..

And finally I am not sure, why the credits dont show for the maps.. they do locally, because they are set explicitly [here](https://github.com/liqd/adhocracy-plus/blob/23611c276e5f3a1ba1ad5b4429359e006b6014b7/adhocracy-plus/config/settings/base.py#L494), but this must be overwritten on the servers somewhere, because there they dont show. Maybe we could have a look together tomorrow @rmader ?