### PR TITLE
apps/embed/assets: Work around login popup not closing

### DIFF
--- a/apps/embed/assets/embed.js
+++ b/apps/embed/assets/embed.js
@@ -32,7 +32,12 @@ $(document).ready(function () {
 
   // FIXME: use consistent wording (URL/href/path)
   window.adhocracy4.getCurrentPath = function () {
-    return currentPath
+    // currentPath is currently broken - it will result in not closing
+    // the login popup. Using login_success will make us close the popup
+    // and return to the initial page. This is not correct, but better
+    // and consistent with the login button on the embed frame.
+    // return currentPath
+    return '/embed/login_success'
   }
 
   var headers = {


### PR DESCRIPTION
This affects cases when people login from the login-link shown
e.g. above comments.