### PR TITLE
makefile: silence non-critical warning when probing for gsed

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ SOURCE_DIRS = adhocracy-plus apps tests
 ARGUMENTS=$(filter-out $(firstword $(MAKECMDGOALS)), $(MAKECMDGOALS))
 
 SED = sed
-ifneq (, $(shell command -v gsed))
+ifneq (, $(shell command -v gsed;))
 	SED = gsed
 endif
 


### PR DESCRIPTION
Fix the `make: command: Commant not found` warning during build. Adding the semicolon forces bash to skip some builtin optimizations and actually execute the command.