### PR TITLE
apps/account: move regsiter info text above button - fixes #387

### DIFF
--- a/adhocracy-plus/templates/account/signup.html
+++ b/adhocracy-plus/templates/account/signup.html
@@ -54,17 +54,17 @@
 
         {% include 'a4_candy_contrib/includes/form_field.html' with field=form.captcha %}
 
-        <div class="u-spacer-bottom-double">
-            <button class="btn btn--primary" type="submit">{% trans "Register" %}</button>
-        </div>
-    </form>
-
-    <p>
+        <p>
         {% blocktrans with data_protection_url=settings.a4_candy_cms_settings.ImportantPages.data_protection_policy.url platformname=settings.a4_candy_cms_settings.OrganisationSettings.platform_name %}
             With your account on {{ platformname }}, you can take part in every public participation project on this platform. This platform allows organisations initiatives to conduct digital participation projects.
             If you have any questions regarding the data protection on this platform you can find <a href="{{ data_protection_url }}" target="_blank">further information here</a>.
         {% endblocktrans %}
-    </p>
+        </p>
+
+        <div class="u-spacer-bottom-double">
+            <button class="btn btn--primary" type="submit">{% trans "Register" %}</button>
+        </div>
+    </form>
 
     {% include "socialaccount/snippets/provider_list.html" with process="login" %}
 {% endblock %}


### PR DESCRIPTION
Luckily it still looks fine with the paragraph in the form. I don't know if it's alright for a11y, though?! @phillimorland Do you know?