### PR TITLE
jd 2021 05 upgrade to new sentry sdk

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -8,7 +8,7 @@ django-capture-tag==1.0
 django-cloudflare-push==0.2.0
 django_csp==3.7
 django-parler==2.2
-raven==6.10.0
+sentry-sdk==1.4.0
 wagtail==2.11.8 # pyup: <2.12
 whitenoise==5.3.0
 xmltodict==0.12.0


### PR DESCRIPTION
The raven sdk has been deprecated for a while now, we should switch to the new sdk. This requires changes in our server setup as well.