### PR TITLE
apps/organisations/landing page: show different text for no projects …

### DIFF
--- a/apps/organisations/templates/a4_candy_organisations/organisation_landing_page.html
+++ b/apps/organisations/templates/a4_candy_organisations/organisation_landing_page.html
@@ -84,7 +84,9 @@
                         </ul>
                     {% endif %}
                 {% else %}
-                    {% if organisation.information %}
+                    {% if request.user.is_authenticated %}
+                        <p>{% blocktrans %}Currently, there are no public participation processes. Please check again later.{% endblocktrans %}</p>
+                    {% elif organisation.information %}
                         {% url 'account_login' as account_login_url %}
                         {% url 'organisation' organisation_slug=organisation.slug as organisation_url %}
                         {% url 'organisation-information' organisation_slug=organisation.slug as organisation_information_url %}


### PR DESCRIPTION
…when user is logged in - fixes #311

I think when this is merged, we can also push the strings to transifex!
Or maybe only after the a4-update (after the merge of the PR there) in which we can also tag a4!