### PR TITLE
Ks 2021 05 disable unload warning outside dashboard

### DIFF
--- a/adhocracy-plus/assets/js/app.js
+++ b/adhocracy-plus/assets/js/app.js
@@ -3,7 +3,6 @@ import 'django'
 import 'select2' // used to skin select element used in livequestions
 import 'slick-carousel' // for project timeline
 
-import './unload_warning.js'
 import '../../../apps/actions/assets/timestamps.js'
 import '../../../apps/dashboard/assets/ajax_modal.js'
 import '../../../apps/maps/assets/map-address.js'

--- a/adhocracy-plus/templates/a4dashboard/base_dashboard.html
+++ b/adhocracy-plus/templates/a4dashboard/base_dashboard.html
@@ -1,5 +1,5 @@
 {% extends "base.html" %}
-{% load i18n rules thumbnail %}
+{% load i18n rules thumbnail static %}
 
 {% block content %}
     {% block dashboard_nav %}
@@ -117,4 +117,8 @@
     <div class="container">
         {% block dashboard_content %}{% endblock %}
     </div>
+{% endblock %}
+
+{% block extra_js %}
+    <script src="{% static 'unload_warning.js' %}"></script>
 {% endblock %}

--- a/webpack.common.js
+++ b/webpack.common.js
@@ -45,6 +45,12 @@ module.exports = {
       ],
       dependOn: 'adhocracy4'
     },
+    unload_warning: {
+      import: [
+        './adhocracy-plus/assets/js/unload_warning.js'
+      ],
+      dependOn: 'adhocracy4'
+    },
     // A4 dependencies - we want all of them to go through webpack
     a4maps_display_point: {
       import: [


### PR DESCRIPTION
fixes #1226

Although this is not the proper way, I guess we should find out why the browser thinks the information in Report Modal is not sent, even though it is.. 
