### PR TITLE
Ks 2021 05 add idea api

### DIFF
--- a/adhocracy-plus/config/urls.py
+++ b/adhocracy-plus/config/urls.py
@@ -25,6 +25,7 @@ from adhocracy4.reports.api import ReportViewSet
 from apps.contrib import views as contrib_views
 from apps.contrib.sitemaps import static_sitemap_index
 from apps.documents.api import DocumentViewSet
+from apps.ideas.api import IdeaViewSet
 from apps.interactiveevents.api import LikesViewSet
 from apps.interactiveevents.api import LiveQuestionViewSet
 from apps.interactiveevents.routers import LikesDefaultRouter
@@ -45,6 +46,7 @@ module_router = a4routers.ModuleDefaultRouter()
 module_router.register(r'documents', DocumentViewSet, basename='chapters')
 module_router.register(r'interactiveevents/livequestions', LiveQuestionViewSet,
                        basename='interactiveevents')
+module_router.register(r'ideas', IdeaViewSet, basename='ideas')
 
 likes_router = LikesDefaultRouter()
 likes_router.register(r'likes', LikesViewSet, basename='likes')

--- a/apps/ideas/api.py
+++ b/apps/ideas/api.py
@@ -1,0 +1,28 @@
+from rest_framework import mixins
+from rest_framework import viewsets
+
+from adhocracy4.api.mixins import ModuleMixin
+from adhocracy4.api.permissions import ViewSetRulesPermission
+
+from .models import Idea
+from .serializers import IdeaSerializer
+
+
+class IdeaViewSet(ModuleMixin,
+                  mixins.ListModelMixin,
+                  mixins.RetrieveModelMixin,
+                  viewsets.GenericViewSet,
+                  ):
+
+    serializer_class = IdeaSerializer
+    permission_classes = (ViewSetRulesPermission,)
+    lookup_field = 'pk'
+
+    def get_permission_object(self):
+        return self.module
+
+    def get_queryset(self):
+        ideas = Idea.objects\
+            .filter(module=self.module)\
+            .order_by('created')
+        return ideas

--- a/apps/ideas/serializers.py
+++ b/apps/ideas/serializers.py
@@ -1,0 +1,10 @@
+from rest_framework import serializers
+
+from .models import Idea
+
+
+class IdeaSerializer(serializers.ModelSerializer):
+
+    class Meta:
+        model = Idea
+        fields = ('name', 'description')


### PR DESCRIPTION
Very basic idea api that only gives you title and description.

Idea list is available under /api/modules/<module_pk>/ideas or equivalently django.urls.reverse('ideas-list', kwargs={'module_pk':module_pk})

Idea detail is available under /api/modules/<module_pk>/ideas/<pk> or equivalently django.urls.reverse('ideas-detail', kwargs={'module_pk':module_pjk, 'pk':pk})