### PR TITLE
apps/exports: use export mixins from a4

### DIFF
--- a/apps/budgeting/exports.py
+++ b/apps/budgeting/exports.py
@@ -3,25 +3,24 @@ from django.utils.translation import ugettext as _
 from rules.contrib.views import PermissionRequiredMixin
 
 from adhocracy4.comments.models import Comment
-from adhocracy4.exports import mixins as a4_export_mixins
+from adhocracy4.exports import mixins
 from adhocracy4.exports import views as a4_export_views
-from apps.exports import mixins as export_mixins
 
 from . import models
 
 
 class ProposalExportView(PermissionRequiredMixin,
-                         export_mixins.ItemExportWithReferenceNumberMixin,
-                         a4_export_mixins.ItemExportWithLinkMixin,
-                         a4_export_mixins.ExportModelFieldsMixin,
-                         a4_export_mixins.ItemExportWithCategoriesMixin,
-                         a4_export_mixins.ItemExportWithLabelsMixin,
-                         a4_export_mixins.ItemExportWithLocationMixin,
-                         export_mixins.UserGeneratedContentExportMixin,
-                         a4_export_mixins.ItemExportWithRatesMixin,
-                         a4_export_mixins.ItemExportWithCommentCountMixin,
-                         export_mixins.ItemExportWithModeratorFeedback,
-                         export_mixins.ItemExportWithModeratorRemark,
+                         mixins.ItemExportWithReferenceNumberMixin,
+                         mixins.ItemExportWithLinkMixin,
+                         mixins.ExportModelFieldsMixin,
+                         mixins.ItemExportWithCategoriesMixin,
+                         mixins.ItemExportWithLabelsMixin,
+                         mixins.ItemExportWithLocationMixin,
+                         mixins.UserGeneratedContentExportMixin,
+                         mixins.ItemExportWithRatesMixin,
+                         mixins.ItemExportWithCommentCountMixin,
+                         mixins.ItemExportWithModeratorFeedback,
+                         mixins.ItemExportWithModeratorRemark,
                          a4_export_views.BaseItemExportView):
     model = models.Proposal
     fields = ['name', 'description', 'budget']
@@ -45,12 +44,12 @@ class ProposalExportView(PermissionRequiredMixin,
 
 class ProposalCommentExportView(
         PermissionRequiredMixin,
-        a4_export_mixins.ItemExportWithLinkMixin,
-        a4_export_mixins.ExportModelFieldsMixin,
-        export_mixins.UserGeneratedContentExportMixin,
-        a4_export_mixins.ItemExportWithRatesMixin,
-        export_mixins.ReferenceExportWithRepliesToMixin,
-        export_mixins.CommentExportWithRepliesToMixin,
+        mixins.ItemExportWithLinkMixin,
+        mixins.ExportModelFieldsMixin,
+        mixins.UserGeneratedContentExportMixin,
+        mixins.ItemExportWithRatesMixin,
+        mixins.CommentExportWithRepliesToReferenceMixin,
+        mixins.CommentExportWithRepliesToMixin,
         a4_export_views.BaseItemExportView
 ):
 

--- a/apps/debate/exports.py
+++ b/apps/debate/exports.py
@@ -3,7 +3,7 @@ from django.utils.translation import ugettext as _
 from rules.contrib.views import PermissionRequiredMixin
 
 from adhocracy4.comments.models import Comment
-from adhocracy4.exports import mixins as a4_export_mixins
+from adhocracy4.exports import mixins
 from adhocracy4.exports import views as a4_export_views
 from apps.exports import mixins as export_mixins
 
@@ -11,11 +11,11 @@ from . import models
 
 
 class SubjectExportView(PermissionRequiredMixin,
-                        export_mixins.ItemExportWithReferenceNumberMixin,
-                        a4_export_mixins.ItemExportWithLinkMixin,
-                        a4_export_mixins.ExportModelFieldsMixin,
-                        export_mixins.UserGeneratedContentExportMixin,
-                        a4_export_mixins.ItemExportWithCommentCountMixin,
+                        mixins.ItemExportWithReferenceNumberMixin,
+                        mixins.ItemExportWithLinkMixin,
+                        mixins.ExportModelFieldsMixin,
+                        mixins.UserGeneratedContentExportMixin,
+                        mixins.ItemExportWithCommentCountMixin,
                         a4_export_views.BaseItemExportView):
     model = models.Subject
     fields = ['name']
@@ -35,13 +35,13 @@ class SubjectExportView(PermissionRequiredMixin,
 
 
 class SubjectCommentExportView(PermissionRequiredMixin,
-                               a4_export_mixins.ItemExportWithLinkMixin,
-                               a4_export_mixins.ExportModelFieldsMixin,
+                               mixins.ItemExportWithLinkMixin,
+                               mixins.ExportModelFieldsMixin,
                                export_mixins.CommentExportWithCategoriesMixin,
-                               export_mixins.UserGeneratedContentExportMixin,
-                               a4_export_mixins.ItemExportWithRatesMixin,
-                               export_mixins.ReferenceExportWithRepliesToMixin,
-                               export_mixins.CommentExportWithRepliesToMixin,
+                               mixins.UserGeneratedContentExportMixin,
+                               mixins.ItemExportWithRatesMixin,
+                               mixins.CommentExportWithRepliesToReferenceMixin,
+                               mixins.CommentExportWithRepliesToMixin,
                                a4_export_views.BaseItemExportView):
 
     model = Comment

--- a/apps/documents/exports.py
+++ b/apps/documents/exports.py
@@ -3,18 +3,17 @@ from django.utils.translation import ugettext as _
 from rules.contrib.views import PermissionRequiredMixin
 
 from adhocracy4.comments.models import Comment
-from adhocracy4.exports import mixins as a4_export_mixins
+from adhocracy4.exports import mixins
 from adhocracy4.exports import views as a4_export_views
-from apps.exports import mixins as export_mixins
 
 
 class DocumentExportView(
         PermissionRequiredMixin,
-        a4_export_mixins.ItemExportWithLinkMixin,
-        a4_export_mixins.ExportModelFieldsMixin,
-        export_mixins.UserGeneratedContentExportMixin,
-        a4_export_mixins.ItemExportWithRatesMixin,
-        export_mixins.CommentExportWithRepliesToMixin,
+        mixins.ItemExportWithLinkMixin,
+        mixins.ExportModelFieldsMixin,
+        mixins.UserGeneratedContentExportMixin,
+        mixins.ItemExportWithRatesMixin,
+        mixins.CommentExportWithRepliesToMixin,
         a4_export_views.BaseItemExportView
 ):
 

--- a/apps/exports/mixins.py
+++ b/apps/exports/mixins.py
@@ -1,82 +1,18 @@
 from django.conf import settings
-from django.core.exceptions import ObjectDoesNotExist
 from django.utils.translation import ugettext as _
 
-from adhocracy4.exports import unescape_and_strip_html
 from adhocracy4.exports.mixins import VirtualFieldMixin
 
 
-class ItemExportWithReferenceNumberMixin(VirtualFieldMixin):
-
-    def get_virtual_fields(self, virtual):
-        if 'reference_number' not in virtual:
-            virtual['reference_number'] = _('Reference No.')
-        return super().get_virtual_fields(virtual)
-
-    def get_reference_number_data(self, item):
-        if hasattr(item, 'reference_number'):
-            return item.reference_number
-        return ''
-
-
-class ItemExportWithModeratorFeedback(VirtualFieldMixin):
-    def get_virtual_fields(self, virtual):
-        if 'moderator_feedback' not in virtual:
-            virtual['moderator_feedback'] = _('Moderator feedback')
-        if 'moderator_statement' not in virtual:
-            virtual['moderator_statement'] = _('Official Statement')
-        return super().get_virtual_fields(virtual)
-
-    def get_moderator_feedback_data(self, item):
-        return item.get_moderator_feedback_display()
-
-    def get_moderator_statement_data(self, item):
-        if item.moderator_statement:
-            return unescape_and_strip_html(item.moderator_statement.statement)
-        return ''
-
-
-class ItemExportWithModeratorRemark(VirtualFieldMixin):
-    def get_virtual_fields(self, virtual):
-        if 'moderator_remark' not in virtual:
-            virtual['moderator_remark'] = _('Remark')
-        return super().get_virtual_fields(virtual)
-
-    def get_moderator_remark_data(self, item):
-        remark = item.remark
-        if remark:
-            return unescape_and_strip_html(remark.remark)
-        return ''
-
-
-class UserGeneratedContentExportMixin(VirtualFieldMixin):
-    def get_virtual_fields(self, virtual):
-        if 'creator' not in virtual:
-            virtual['creator'] = _('Creator')
-        if 'created' not in virtual:
-            virtual['created'] = _('Created')
-        return super().get_virtual_fields(virtual)
-
-    def get_creator_data(self, item):
-        return item.creator.username
-
-    def get_created_data(self, item):
-        return item.created.isoformat()
-
-
-class CommentExportWithRepliesToMixin(VirtualFieldMixin):
-    def get_virtual_fields(self, virtual):
-        virtual['replies_to'] = _('Reply to Comment')
-        return super().get_virtual_fields(virtual)
-
-    def get_replies_to_data(self, comment):
-        try:
-            return comment.parent_comment.get().pk
-        except ObjectDoesNotExist:
-            return ''
-
-
 class CommentExportWithCategoriesMixin(VirtualFieldMixin):
+    """
+    Adds categories to the comment export.
+
+    To be used with comments with categories like in the debate module.
+
+    ATTENTION: if this export is used elsewhere, do not copy over,
+    but move to A4 (as the comments are also there!)
+    """
 
     def get_virtual_fields(self, virtual):
         if 'categories' not in virtual:
@@ -99,15 +35,3 @@ class CommentExportWithCategoriesMixin(VirtualFieldMixin):
                     categories.append(category)
             return ", ".join(categories)
         return ''
-
-
-class ReferenceExportWithRepliesToMixin(VirtualFieldMixin):
-    def get_virtual_fields(self, virtual):
-        virtual['replies_to_reference'] = _('Reply to Reference')
-        return super().get_virtual_fields(virtual)
-
-    def get_replies_to_reference_data(self, comment):
-        if hasattr(comment.content_object, 'reference_number'):
-            return comment.content_object.reference_number
-        else:
-            return ''

--- a/apps/ideas/exports.py
+++ b/apps/ideas/exports.py
@@ -3,24 +3,23 @@ from django.utils.translation import ugettext as _
 from rules.contrib.views import PermissionRequiredMixin
 
 from adhocracy4.comments.models import Comment
-from adhocracy4.exports import mixins as a4_export_mixins
+from adhocracy4.exports import mixins
 from adhocracy4.exports import views as a4_export_views
-from apps.exports import mixins as export_mixins
 
 from . import models
 
 
 class IdeaExportView(PermissionRequiredMixin,
-                     export_mixins.ItemExportWithReferenceNumberMixin,
-                     a4_export_mixins.ItemExportWithLinkMixin,
-                     a4_export_mixins.ExportModelFieldsMixin,
-                     a4_export_mixins.ItemExportWithCategoriesMixin,
-                     a4_export_mixins.ItemExportWithLabelsMixin,
-                     export_mixins.UserGeneratedContentExportMixin,
-                     a4_export_mixins.ItemExportWithRatesMixin,
-                     a4_export_mixins.ItemExportWithCommentCountMixin,
-                     export_mixins.ItemExportWithModeratorFeedback,
-                     export_mixins.ItemExportWithModeratorRemark,
+                     mixins.ItemExportWithReferenceNumberMixin,
+                     mixins.ItemExportWithLinkMixin,
+                     mixins.ExportModelFieldsMixin,
+                     mixins.ItemExportWithCategoriesMixin,
+                     mixins.ItemExportWithLabelsMixin,
+                     mixins.UserGeneratedContentExportMixin,
+                     mixins.ItemExportWithRatesMixin,
+                     mixins.ItemExportWithCommentCountMixin,
+                     mixins.ItemExportWithModeratorFeedback,
+                     mixins.ItemExportWithModeratorRemark,
                      a4_export_views.BaseItemExportView):
     model = models.Idea
     fields = ['name', 'description']
@@ -43,12 +42,12 @@ class IdeaExportView(PermissionRequiredMixin,
 
 
 class IdeaCommentExportView(PermissionRequiredMixin,
-                            a4_export_mixins.ItemExportWithLinkMixin,
-                            a4_export_mixins.ExportModelFieldsMixin,
-                            export_mixins.UserGeneratedContentExportMixin,
-                            a4_export_mixins.ItemExportWithRatesMixin,
-                            export_mixins.ReferenceExportWithRepliesToMixin,
-                            export_mixins.CommentExportWithRepliesToMixin,
+                            mixins.ItemExportWithLinkMixin,
+                            mixins.ExportModelFieldsMixin,
+                            mixins.UserGeneratedContentExportMixin,
+                            mixins.ItemExportWithRatesMixin,
+                            mixins.CommentExportWithRepliesToReferenceMixin,
+                            mixins.CommentExportWithRepliesToMixin,
                             a4_export_views.BaseItemExportView):
 
     model = Comment

--- a/apps/mapideas/exports.py
+++ b/apps/mapideas/exports.py
@@ -3,25 +3,24 @@ from django.utils.translation import ugettext as _
 from rules.contrib.views import PermissionRequiredMixin
 
 from adhocracy4.comments.models import Comment
-from adhocracy4.exports import mixins as a4_export_mixins
+from adhocracy4.exports import mixins
 from adhocracy4.exports import views as a4_export_views
-from apps.exports import mixins as export_mixins
 
 from . import models
 
 
 class MapIdeaExportView(PermissionRequiredMixin,
-                        export_mixins.ItemExportWithReferenceNumberMixin,
-                        a4_export_mixins.ItemExportWithLinkMixin,
-                        a4_export_mixins.ExportModelFieldsMixin,
-                        a4_export_mixins.ItemExportWithCategoriesMixin,
-                        a4_export_mixins.ItemExportWithLabelsMixin,
-                        a4_export_mixins.ItemExportWithLocationMixin,
-                        export_mixins.UserGeneratedContentExportMixin,
-                        a4_export_mixins.ItemExportWithRatesMixin,
-                        a4_export_mixins.ItemExportWithCommentCountMixin,
-                        export_mixins.ItemExportWithModeratorFeedback,
-                        export_mixins.ItemExportWithModeratorRemark,
+                        mixins.ItemExportWithReferenceNumberMixin,
+                        mixins.ItemExportWithLinkMixin,
+                        mixins.ExportModelFieldsMixin,
+                        mixins.ItemExportWithCategoriesMixin,
+                        mixins.ItemExportWithLabelsMixin,
+                        mixins.ItemExportWithLocationMixin,
+                        mixins.UserGeneratedContentExportMixin,
+                        mixins.ItemExportWithRatesMixin,
+                        mixins.ItemExportWithCommentCountMixin,
+                        mixins.ItemExportWithModeratorFeedback,
+                        mixins.ItemExportWithModeratorRemark,
                         a4_export_views.BaseItemExportView):
     model = models.MapIdea
     fields = ['name', 'description']
@@ -44,12 +43,12 @@ class MapIdeaExportView(PermissionRequiredMixin,
 
 
 class MapIdeaCommentExportView(PermissionRequiredMixin,
-                               a4_export_mixins.ItemExportWithLinkMixin,
-                               a4_export_mixins.ExportModelFieldsMixin,
-                               export_mixins.UserGeneratedContentExportMixin,
-                               a4_export_mixins.ItemExportWithRatesMixin,
-                               export_mixins.ReferenceExportWithRepliesToMixin,
-                               export_mixins.CommentExportWithRepliesToMixin,
+                               mixins.ItemExportWithLinkMixin,
+                               mixins.ExportModelFieldsMixin,
+                               mixins.UserGeneratedContentExportMixin,
+                               mixins.ItemExportWithRatesMixin,
+                               mixins.CommentExportWithRepliesToReferenceMixin,
+                               mixins.CommentExportWithRepliesToMixin,
                                a4_export_views.BaseItemExportView):
 
     model = Comment

--- a/apps/polls/exports.py
+++ b/apps/polls/exports.py
@@ -3,18 +3,17 @@ from django.utils.translation import ugettext as _
 from rules.contrib.views import PermissionRequiredMixin
 
 from adhocracy4.comments.models import Comment
-from adhocracy4.exports import mixins as a4_export_mixins
+from adhocracy4.exports import mixins
 from adhocracy4.exports import views as a4_export_views
-from apps.exports import mixins as export_mixins
 
 
 class PollCommentExportView(
         PermissionRequiredMixin,
-        a4_export_mixins.ItemExportWithLinkMixin,
-        a4_export_mixins.ExportModelFieldsMixin,
-        export_mixins.UserGeneratedContentExportMixin,
-        a4_export_mixins.ItemExportWithRatesMixin,
-        export_mixins.CommentExportWithRepliesToMixin,
+        mixins.ItemExportWithLinkMixin,
+        mixins.ExportModelFieldsMixin,
+        mixins.UserGeneratedContentExportMixin,
+        mixins.ItemExportWithRatesMixin,
+        mixins.CommentExportWithRepliesToMixin,
         a4_export_views.BaseItemExportView
 ):
 

--- a/apps/topicprio/exports.py
+++ b/apps/topicprio/exports.py
@@ -3,22 +3,21 @@ from django.utils.translation import ugettext as _
 from rules.contrib.views import PermissionRequiredMixin
 
 from adhocracy4.comments.models import Comment
-from adhocracy4.exports import mixins as a4_export_mixins
+from adhocracy4.exports import mixins
 from adhocracy4.exports import views as a4_export_views
-from apps.exports import mixins as export_mixins
 
 from . import models
 
 
 class TopicExportView(PermissionRequiredMixin,
-                      export_mixins.ItemExportWithReferenceNumberMixin,
-                      a4_export_mixins.ItemExportWithLinkMixin,
-                      a4_export_mixins.ExportModelFieldsMixin,
-                      a4_export_mixins.ItemExportWithCategoriesMixin,
-                      a4_export_mixins.ItemExportWithLabelsMixin,
-                      export_mixins.UserGeneratedContentExportMixin,
-                      a4_export_mixins.ItemExportWithRatesMixin,
-                      a4_export_mixins.ItemExportWithCommentCountMixin,
+                      mixins.ItemExportWithReferenceNumberMixin,
+                      mixins.ItemExportWithLinkMixin,
+                      mixins.ExportModelFieldsMixin,
+                      mixins.ItemExportWithCategoriesMixin,
+                      mixins.ItemExportWithLabelsMixin,
+                      mixins.UserGeneratedContentExportMixin,
+                      mixins.ItemExportWithRatesMixin,
+                      mixins.ItemExportWithCommentCountMixin,
                       a4_export_views.BaseItemExportView):
     model = models.Topic
     fields = ['name', 'description']
@@ -41,12 +40,12 @@ class TopicExportView(PermissionRequiredMixin,
 
 
 class TopicCommentExportView(PermissionRequiredMixin,
-                             a4_export_mixins.ItemExportWithLinkMixin,
-                             a4_export_mixins.ExportModelFieldsMixin,
-                             export_mixins.UserGeneratedContentExportMixin,
-                             a4_export_mixins.ItemExportWithRatesMixin,
-                             export_mixins.ReferenceExportWithRepliesToMixin,
-                             export_mixins.CommentExportWithRepliesToMixin,
+                             mixins.ItemExportWithLinkMixin,
+                             mixins.ExportModelFieldsMixin,
+                             mixins.UserGeneratedContentExportMixin,
+                             mixins.ItemExportWithRatesMixin,
+                             mixins.CommentExportWithRepliesToReferenceMixin,
+                             mixins.CommentExportWithRepliesToMixin,
                              a4_export_views.BaseItemExportView):
 
     model = Comment

--- a/tests/exports/test_comment_exports.py
+++ b/tests/exports/test_comment_exports.py
@@ -1,7 +1,8 @@
 import pytest
 
 from adhocracy4.comments.models import Comment
-from apps.exports import mixins
+from adhocracy4.exports import mixins
+from apps.exports.mixins import CommentExportWithCategoriesMixin
 
 
 @pytest.mark.django_db
@@ -9,20 +10,20 @@ def test_reply_to_mixin(idea, comment_factory):
     mixin = mixins.CommentExportWithRepliesToMixin()
 
     virtual = mixin.get_virtual_fields({})
-    assert 'replies_to' in virtual
+    assert 'replies_to_comment' in virtual
 
     comment = comment_factory(content_object=idea)
     reply_comment = comment_factory(content_object=comment)
 
     assert Comment.objects.count() == 2
 
-    assert mixin.get_replies_to_data(comment) == ''
-    assert mixin.get_replies_to_data(reply_comment) == comment.id
+    assert mixin.get_replies_to_comment_data(comment) == ''
+    assert mixin.get_replies_to_comment_data(reply_comment) == comment.id
 
 
 @pytest.mark.django_db
 def test_reply_to_reference_mixin(idea, comment_factory):
-    mixin = mixins.ReferenceExportWithRepliesToMixin()
+    mixin = mixins.CommentExportWithRepliesToReferenceMixin()
 
     virtual = mixin.get_virtual_fields({})
     assert 'replies_to_reference' in virtual
@@ -39,7 +40,7 @@ def test_reply_to_reference_mixin(idea, comment_factory):
 
 @pytest.mark.django_db
 def test_comment_export_with_categories_mixin(idea, comment_factory):
-    mixin = mixins.CommentExportWithCategoriesMixin()
+    mixin = CommentExportWithCategoriesMixin()
 
     virtual = mixin.get_virtual_fields({})
     assert 'categories' in virtual

--- a/tests/exports/test_item_exports.py
+++ b/tests/exports/test_item_exports.py
@@ -1,6 +1,6 @@
 import pytest
 
-from apps.exports import mixins
+from adhocracy4.exports import mixins
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
still very untested, just not to forget what to do.

depends on a4, which needs to be updated.

maybe also fix #1359 