### PR TITLE
jd 2021 07 devtool use source-map in prod

### DIFF
--- a/webpack.prod.js
+++ b/webpack.prod.js
@@ -3,7 +3,7 @@ const common = require('./webpack.common.js')
 const TerserPlugin = require('terser-webpack-plugin')
 
 module.exports = merge(common, {
-  devtool: 'eval',
+  devtool: 'source-map',
   optimization: {
     minimize: true,
     minimizer: [


### PR DESCRIPTION
According to the docs `eval` shouldn't be used in production. We use `source-map` in other projects, so this makes it consistent.