### PR TITLE
Sm 2021 11 update makemessages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -123,8 +123,8 @@ lint-fix:
 
 .PHONY: po
 po:
-	$(VIRTUAL_ENV)/bin/python manage.py makemessages -d django --extension html,email,py --ignore '$(CURDIR)/node_modules/adhocracy4/adhocracy4/*'
-	$(VIRTUAL_ENV)/bin/python manage.py makemessages -d djangojs --ignore '$(VIRTUAL_ENV)/*' --ignore '$(CURDIR)/node_modules/dsgvo-video-embed/dist/*'
+	$(VIRTUAL_ENV)/bin/python manage.py makemessages --all -d django --extension html,email,py --ignore '$(CURDIR)/node_modules/adhocracy4/adhocracy4/*'
+	$(VIRTUAL_ENV)/bin/python manage.py makemessages --all -d djangojs --ignore '$(VIRTUAL_ENV)/*' --ignore '$(CURDIR)/node_modules/dsgvo-video-embed/dist/*'
 	$(foreach file, $(wildcard locale-*/locale/*/LC_MESSAGES/django*.po), \
 		$(SED) -i 's%#: .*/adhocracy4%#: adhocracy4%' $(file);)
 	$(foreach file, $(wildcard locale-*/locale/*/LC_MESSAGES/django*.po), \

--- a/locale-source/locale/de/LC_MESSAGES/django.po
+++ b/locale-source/locale/de/LC_MESSAGES/django.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: adhocracy-plus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-19 10:30+0200\n"
+"POT-Creation-Date: 2021-11-19 13:49+0100\n"
 "PO-Revision-Date: 2020-11-12 13:23+0000\n"
 "Last-Translator: Frederik Wegener <frederik.wegener@liqd.de>, 2021\n"
 "Language-Team: German (https://www.transifex.com/liqd/teams/109316/de/)\n"
@@ -23,6 +23,374 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
+#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
+msgid ""
+"In this section, you can create\n"
+"categories. If you create any, each contribution has to be assigned\n"
+"to one of them. This way, content can be classified."
+msgstr ""
+"Hier können Sie Kategorien anlegen. Dadurch können alle Beiträge einer "
+"Kategorie zugeordnet und entsprechend gefiltert werden."
+
+#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:21
+#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:21
+msgid "Add category"
+msgstr "Kategorie hinzufügen"
+
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard.html:4
+#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:51
+msgid "Dashboard"
+msgstr "Organisationsverwaltung"
+
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:5
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:5
+#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:24
+msgid "Project Settings"
+msgstr "Projekteinstellungen"
+
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:15
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:33
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:15
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:33
+#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:49
+#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:103
+msgid "Missing fields for publication"
+msgstr "Benötigte Felder zur Veröffentlichung"
+
+#: adhocracy4/dashboard/templates/a4dashboard/base_form_module.html:18
+#: adhocracy4/dashboard/templates/a4dashboard/base_form_project.html:18
+#: adhocracy4/dashboard/templates/a4dashboard/base_form_module.html:18
+#: adhocracy4/dashboard/templates/a4dashboard/base_form_project.html:18
+#: apps/activities/templates/a4_candy_activities/activities_dashboard.html:17
+#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_form.html:30
+#: apps/budgeting/templates/a4_candy_budgeting/proposal_moderate_form.html:39
+#: apps/debate/templates/a4_candy_debate/includes/subject_form.html:11
+#: apps/ideas/templates/a4_candy_ideas/idea_moderate_form.html:44
+#: apps/ideas/templates/a4_candy_ideas/includes/idea_form.html:24
+#: apps/interactiveevents/templates/a4_candy_interactive_events/extrafields_dashboard_form.html:19
+#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_form.html:28
+#: apps/mapideas/templates/a4_candy_mapideas/mapidea_moderate_form.html:43
+#: apps/moderatorremark/templates/a4_candy_moderatorremark/includes/popover_remark.html:27
+#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_form.html:15
+#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_form.html:22
+#: adhocracy-plus/templates/a4dashboard/base_form_module.html:23
+#: adhocracy-plus/templates/a4dashboard/base_form_project.html:23
+msgid "Save"
+msgstr "Speichern"
+
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:9
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:9
+#: adhocracy-plus/templates/a4dashboard/blueprint_list.html:4
+#: adhocracy-plus/templates/a4dashboard/project_list.html:13
+msgid "New Project"
+msgstr "Neues Projekt"
+
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:17
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:17
+msgid "Phase"
+msgstr "Phase"
+
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:23
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:23
+#: adhocracy-plus/templates/a4dashboard/includes/blueprint_list_tile.html:15
+msgid "Select"
+msgstr "Auswählen"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/form_field.html:6
+#: adhocracy4/dashboard/templates/a4dashboard/includes/form_field.html:6
+msgid "Missing field for publication"
+msgstr "Benötigtes Feld zur Veröffentlichung"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:39
+#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:39
+#: adhocracy-plus/templates/a4dashboard/includes/preview.html:7
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:34
+msgid "Preview"
+msgstr "Vorschau"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:9
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:41
+#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:9
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:41
+#: apps/contrib/templates/a4_candy_contrib/includes/map_filter_and_sort.html:8
+#: apps/contrib/templates/a4_candy_contrib/includes/map_filter_and_sort.html:14
+#: apps/debate/templates/a4_candy_debate/includes/subject_dashboard_list_item.html:14
+#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_list_item.html:15
+#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_dashboard_list_item.html:14
+#: adhocracy-plus/templates/a4dashboard/includes/preview.html:9
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:36
+msgid "View"
+msgstr "Ansicht"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:16
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:16
+#, python-format
+msgid "%(value)s from %(max)s"
+msgstr "%(value)s von %(max)s"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:17
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:17
+msgid "required fields for publication"
+msgstr "benötigte Felder zur Veröffentlichung"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:27
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:27
+#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:12
+#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:46
+msgid "Publish"
+msgstr "Veröffentlichen"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:31
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:31
+#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:19
+msgid "Unpublish"
+msgstr "Depublizieren"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:7
+msgid "Create project based on"
+msgstr "Projekt anlegen basierend auf"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:23
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:23
+#: adhocracy-plus/templates/a4dashboard/project_create_form.html:41
+msgid ""
+"After saving the draft project you can further customize and edit your "
+"project and eventually publish it."
+msgstr ""
+"Nachdem der Projektentwurf gespeichert wurde, können in einem weiteren "
+"Schritt Einstellungen angepasst und zusätzliche Informationen angegeben "
+"werden. Wenn alle benötigten Informationen eingegeben sind, kann das Projekt "
+"veröffentlicht werden."
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:25
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:25
+#: adhocracy-plus/templates/a4dashboard/project_create_form.html:46
+msgid "Create draft"
+msgstr "Projektentwurf anlegen"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:27
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:27
+#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_form.html:29
+#: apps/budgeting/templates/a4_candy_budgeting/proposal_confirm_delete.html:15
+#: apps/budgeting/templates/a4_candy_budgeting/proposal_moderate_form.html:38
+#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:40
+#: apps/debate/templates/a4_candy_debate/includes/subject_form.html:10
+#: apps/debate/templates/a4_candy_debate/subject_confirm_delete.html:15
+#: apps/embed/templates/a4_candy_embed/embed.html:47
+#: apps/ideas/templates/a4_candy_ideas/idea_confirm_delete.html:16
+#: apps/ideas/templates/a4_candy_ideas/idea_moderate_form.html:43
+#: apps/ideas/templates/a4_candy_ideas/includes/idea_form.html:23
+#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_form.html:27
+#: apps/mapideas/templates/a4_candy_mapideas/mapidea_confirm_delete.html:15
+#: apps/mapideas/templates/a4_candy_mapideas/mapidea_moderate_form.html:42
+#: apps/newsletters/templates/a4_candy_newsletters/restricted_newsletter_dashboard_form.html:29
+#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_form.html:14
+#: apps/offlineevents/templates/a4_candy_offlineevents/offlineevent_confirm_delete.html:15
+#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_form.html:21
+#: apps/topicprio/templates/a4_candy_topicprio/topic_confirm_delete.html:15
+#: adhocracy-plus/templates/a4dashboard/project_create_form.html:45
+msgid "Cancel"
+msgstr "Abbrechen"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:7
+#: apps/projects/templates/a4_candy_projects/project_list.html:4
+#: adhocracy-plus/templates/a4dashboard/base_project_list.html:16
+#: adhocracy-plus/templates/a4dashboard/project_list.html:4
+#: adhocracy-plus/templates/a4dashboard/project_list.html:9
+msgid "Projects"
+msgstr "Projekte"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:24
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:24
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:17
+msgid "Finished"
+msgstr "Abgeschlossen"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:27
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:27
+#: adhocracy4/projects/enums.py:14
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:20
+msgid "semipublic"
+msgstr "halb-öffentlich"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:30
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:30
+#: adhocracy4/projects/enums.py:15
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:23
+msgid "private"
+msgstr "privat"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:48
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:48
+#: apps/contrib/templates/a4_candy_contrib/item_detail.html:103
+#: apps/debate/templates/a4_candy_debate/includes/subject_dashboard_list_item.html:19
+#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_list_item.html:20
+#: apps/projects/templates/a4_candy_projects/project_detail.html:112
+#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_dashboard_list_item.html:19
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:42
+msgid "Edit"
+msgstr "Bearbeiten"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:57
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:57
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:65
+msgid "Duplicate"
+msgstr "Duplizieren"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:65
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:65
+#: apps/projects/templates/a4_candy_projects/project_list.html:18
+#: adhocracy-plus/templates/a4dashboard/project_list.html:27
+msgid "We could not find any projects."
+msgstr "Wir konnten keine Projekte finden."
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:5
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:23
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:35
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:47
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:59
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:5
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:23
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:35
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:47
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:59
+msgid "Export"
+msgstr "Export"
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:7
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:7
+msgid ""
+"You can export the results of your participation project as an excel file."
+msgstr ""
+"Sie können die Ergebnisse Ihres Beteiligungsprojektes als Excel-Datei "
+"exportieren."
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:19
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:19
+msgid "here you can export all ideas"
+msgstr "hier können Sie alle Ideen exportieren"
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:31
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:31
+msgid "here you can export all subjects"
+msgstr "hier können Sie alle Themen exportieren"
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:43
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:43
+msgid "here you can export all answers"
+msgstr "hier können Sie alle Antworten exportieren"
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:55
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:55
+msgid "here you can export all comments"
+msgstr "hier können Sie alle Kommentare exportieren"
+
+#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html:15
+#: adhocracy4/dashboard/filter.py:11
+#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html:15
+#: apps/debate/filters.py:12 apps/ideas/views.py:28 apps/topicprio/views.py:21
+#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:4
+#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:10
+#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:11
+msgid "Search"
+msgstr "Suchen"
+
+#: adhocracy4/forms/templates/a4forms/includes/form_field.html:5
+#: adhocracy4/forms/templates/a4forms/includes/form_field.html:5
+#: apps/contrib/templates/a4_candy_contrib/includes/form_field.html:5
+#: adhocracy-plus/templates/account/signup.html:27
+#: adhocracy-plus/templates/account/signup.html:36
+#: adhocracy-plus/templates/socialaccount/signup.html:31
+msgid "This field is required"
+msgstr "Dieses Feld muss ausgefüllt werden"
+
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:14
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:15
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:18
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:19
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:14
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:15
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:18
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:19
+msgid "Remove category"
+msgstr "Kategorie entfernen"
+
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:8
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:8
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:10
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:11
+msgid "Remove the picture"
+msgstr "Bild entfernen"
+
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:12
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:12
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:16
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:17
+msgid "Upload a picture"
+msgstr "Bild hochladen"
+
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:19
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:19
+msgid ""
+"\n"
+"            Your image will be uploaded/removed once you save your changes\n"
+"            at the end of this page.\n"
+"            "
+msgstr ""
+"\n"
+"Ihr Bild wird hochgeladen sobald Sie Ihre Änderungen am Ende der Seite "
+"speichern."
+
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
+msgid ""
+"In this section, you can create\n"
+"labels. If you create any, each contribution can be assigned\n"
+"to one or more of them. This way, content can be classified."
+msgstr ""
+"Hier können Sie Merkmale anlegen. Dadurch können alle Beiträge um ein oder "
+"mehrere Merkmale ergänzt werden."
+
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:21
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:21
+msgid "Add label"
+msgstr "Merkmal hinzufügen"
+
+#: adhocracy4/polls/templates/a4polls/poll_404.html:8
+#: adhocracy4/polls/templates/a4polls/poll_404.html:8
+msgid ""
+"Participation is not possible at the moment. The poll has not been set up "
+"yet."
+msgstr ""
+"Die Beteiligung ist aktuell noch nicht möglich. Die Umfrage wird gerade "
+"angelegt."
+
+#: adhocracy4/polls/templates/a4polls/poll_404.html:15
+#: adhocracy4/polls/templates/a4polls/poll_404.html:15
+msgid "Setup the poll by adding questions and answers in the dashboard."
+msgstr ""
+"Legen Sie die Umfrage an indem Sie Fragen und Antwortmöglichkeiten in der "
+"Projektverwaltung hinzufügen."
+
+#: adhocracy4/polls/templates/a4polls/poll_dashboard.html:5
+#: adhocracy4/polls/templates/a4polls/poll_dashboard.html:5
+msgid "Edit poll"
+msgstr "Umfrage bearbeiten"
 
 #: adhocracy4/categories/dashboard.py:13
 #: apps/exports/mixins.py:19
@@ -49,20 +417,7 @@ msgstr "Kategoriename"
 msgid "Category icon"
 msgstr "Kategorieicon"
 
-#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
-msgid ""
-"In this section, you can create\n"
-"categories. If you create any, each contribution has to be assigned\n"
-"to one of them. This way, content can be classified."
-msgstr ""
-"Hier können Sie Kategorien anlegen. Dadurch können alle Beiträge einer "
-"Kategorie zugeordnet und entsprechend gefiltert werden."
-
-#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:21
-msgid "Add category"
-msgstr "Kategorie hinzufügen"
-
-#: adhocracy4/comments/models.py:53
+#: adhocracy4/comments/models.py:54
 #: adhocracy4/polls/exports.py:41
 #: apps/budgeting/exports.py:75 apps/debate/exports.py:64
 #: apps/documents/exports.py:40 apps/ideas/exports.py:70
@@ -71,7 +426,7 @@ msgctxt "noun"
 msgid "Comment"
 msgstr "Kommentar"
 
-#: adhocracy4/comments/models.py:54
+#: adhocracy4/comments/models.py:55
 #: adhocracy4/exports/mixins/comments.py:46
 #: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_list_item.html:16
 #: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_list_item.html:17
@@ -84,17 +439,17 @@ msgstr "Kommentar"
 msgid "Comments"
 msgstr "Kommentare"
 
-#: adhocracy4/comments/serializers.py:52
-#: adhocracy4/comments/serializers.py:151
+#: adhocracy4/comments/serializers.py:73
+#: adhocracy4/comments/serializers.py:175
 msgid "Please choose a category"
 msgstr "Bitte wählen Sie eine Kategorie"
 
-#: adhocracy4/comments/serializers.py:61
-#: adhocracy4/comments_async/serializers.py:79
+#: adhocracy4/comments/serializers.py:82
+#: adhocracy4/comments_async/serializers.py:84
 msgid "unknown user"
 msgstr "unbekannter Nutzer"
 
-#: adhocracy4/comments_async/serializers.py:58
+#: adhocracy4/comments_async/serializers.py:63
 msgid "Please choose one or more categories."
 msgstr "Bitte wählen Sie eine oder mehrere Kategorien aus."
 
@@ -159,15 +514,6 @@ msgstr "Karte"
 #: adhocracy4/dashboard/dashboard.py:65
 msgid "Edit areasettings"
 msgstr "Kartenbereich bearbeiten"
-
-#: adhocracy4/dashboard/filter.py:11
-#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html:15
-#: apps/debate/filters.py:12 apps/ideas/views.py:28 apps/topicprio/views.py:21
-#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:4
-#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:10
-#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:11
-msgid "Search"
-msgstr "Suchen"
 
 #: adhocracy4/dashboard/filter.py:15
 #: apps/budgeting/views.py:26
@@ -245,193 +591,6 @@ msgstr "Anfangszeit"
 #: adhocracy4/dashboard/mixins.py:207
 msgid "Project successfully duplicated."
 msgstr "Projekt erfolgreich dupliziert."
-
-#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard.html:4
-#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:51
-msgid "Dashboard"
-msgstr "Organisationsverwaltung"
-
-#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:5
-#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:24
-msgid "Project Settings"
-msgstr "Projekteinstellungen"
-
-#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:15
-#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:33
-#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:49
-#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:103
-msgid "Missing fields for publication"
-msgstr "Benötigte Felder zur Veröffentlichung"
-
-#: adhocracy4/dashboard/templates/a4dashboard/base_form_module.html:18
-#: adhocracy4/dashboard/templates/a4dashboard/base_form_project.html:18
-#: apps/activities/templates/a4_candy_activities/activities_dashboard.html:17
-#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_form.html:30
-#: apps/budgeting/templates/a4_candy_budgeting/proposal_moderate_form.html:39
-#: apps/debate/templates/a4_candy_debate/includes/subject_form.html:11
-#: apps/ideas/templates/a4_candy_ideas/idea_moderate_form.html:44
-#: apps/ideas/templates/a4_candy_ideas/includes/idea_form.html:24
-#: apps/interactiveevents/templates/a4_candy_interactive_events/extrafields_dashboard_form.html:19
-#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_form.html:28
-#: apps/mapideas/templates/a4_candy_mapideas/mapidea_moderate_form.html:43
-#: apps/moderatorremark/templates/a4_candy_moderatorremark/includes/popover_remark.html:27
-#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_form.html:15
-#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_form.html:22
-#: adhocracy-plus/templates/a4dashboard/base_form_module.html:23
-#: adhocracy-plus/templates/a4dashboard/base_form_project.html:23
-msgid "Save"
-msgstr "Speichern"
-
-#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:4
-#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:7
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:9
-#: adhocracy-plus/templates/a4dashboard/blueprint_list.html:4
-#: adhocracy-plus/templates/a4dashboard/project_list.html:13
-msgid "New Project"
-msgstr "Neues Projekt"
-
-#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:17
-msgid "Phase"
-msgstr "Phase"
-
-#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:23
-#: adhocracy-plus/templates/a4dashboard/includes/blueprint_list_tile.html:15
-msgid "Select"
-msgstr "Auswählen"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/form_field.html:6
-msgid "Missing field for publication"
-msgstr "Benötigtes Feld zur Veröffentlichung"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:7
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:39
-#: adhocracy-plus/templates/a4dashboard/includes/preview.html:7
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:34
-msgid "Preview"
-msgstr "Vorschau"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:9
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:41
-#: apps/contrib/templates/a4_candy_contrib/includes/map_filter_and_sort.html:8
-#: apps/contrib/templates/a4_candy_contrib/includes/map_filter_and_sort.html:14
-#: apps/debate/templates/a4_candy_debate/includes/subject_dashboard_list_item.html:14
-#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_list_item.html:15
-#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_dashboard_list_item.html:14
-#: adhocracy-plus/templates/a4dashboard/includes/preview.html:9
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:36
-msgid "View"
-msgstr "Ansicht"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:16
-#, python-format
-msgid "%(value)s from %(max)s"
-msgstr "%(value)s von %(max)s"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:17
-msgid "required fields for publication"
-msgstr "benötigte Felder zur Veröffentlichung"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:27
-#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:12
-#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:46
-msgid "Publish"
-msgstr "Veröffentlichen"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:31
-#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:19
-msgid "Unpublish"
-msgstr "Depublizieren"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:4
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:7
-msgid "Create project based on"
-msgstr "Projekt anlegen basierend auf"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:23
-#: adhocracy-plus/templates/a4dashboard/project_create_form.html:41
-msgid ""
-"After saving the draft project you can further customize and edit your "
-"project and eventually publish it."
-msgstr ""
-"Nachdem der Projektentwurf gespeichert wurde, können in einem weiteren "
-"Schritt Einstellungen angepasst und zusätzliche Informationen angegeben "
-"werden. Wenn alle benötigten Informationen eingegeben sind, kann das Projekt "
-"veröffentlicht werden."
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:25
-#: adhocracy-plus/templates/a4dashboard/project_create_form.html:46
-msgid "Create draft"
-msgstr "Projektentwurf anlegen"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:27
-#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_form.html:29
-#: apps/budgeting/templates/a4_candy_budgeting/proposal_confirm_delete.html:15
-#: apps/budgeting/templates/a4_candy_budgeting/proposal_moderate_form.html:38
-#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:40
-#: apps/debate/templates/a4_candy_debate/includes/subject_form.html:10
-#: apps/debate/templates/a4_candy_debate/subject_confirm_delete.html:15
-#: apps/embed/templates/a4_candy_embed/embed.html:47
-#: apps/ideas/templates/a4_candy_ideas/idea_confirm_delete.html:16
-#: apps/ideas/templates/a4_candy_ideas/idea_moderate_form.html:43
-#: apps/ideas/templates/a4_candy_ideas/includes/idea_form.html:23
-#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_form.html:27
-#: apps/mapideas/templates/a4_candy_mapideas/mapidea_confirm_delete.html:15
-#: apps/mapideas/templates/a4_candy_mapideas/mapidea_moderate_form.html:42
-#: apps/newsletters/templates/a4_candy_newsletters/restricted_newsletter_dashboard_form.html:29
-#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_form.html:14
-#: apps/offlineevents/templates/a4_candy_offlineevents/offlineevent_confirm_delete.html:15
-#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_form.html:21
-#: apps/topicprio/templates/a4_candy_topicprio/topic_confirm_delete.html:15
-#: adhocracy-plus/templates/a4dashboard/project_create_form.html:45
-msgid "Cancel"
-msgstr "Abbrechen"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:4
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:7
-#: apps/projects/templates/a4_candy_projects/project_list.html:4
-#: adhocracy-plus/templates/a4dashboard/base_project_list.html:16
-#: adhocracy-plus/templates/a4dashboard/project_list.html:4
-#: adhocracy-plus/templates/a4dashboard/project_list.html:9
-msgid "Projects"
-msgstr "Projekte"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:24
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:17
-msgid "Finished"
-msgstr "Abgeschlossen"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:27
-#: adhocracy4/projects/enums.py:14
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:20
-msgid "semipublic"
-msgstr "halb-öffentlich"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:30
-#: adhocracy4/projects/enums.py:15
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:23
-msgid "private"
-msgstr "privat"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:48
-#: apps/contrib/templates/a4_candy_contrib/item_detail.html:103
-#: apps/debate/templates/a4_candy_debate/includes/subject_dashboard_list_item.html:19
-#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_list_item.html:20
-#: apps/projects/templates/a4_candy_projects/project_detail.html:112
-#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_dashboard_list_item.html:19
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:42
-msgid "Edit"
-msgstr "Bearbeiten"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:57
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:65
-msgid "Duplicate"
-msgstr "Duplizieren"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:65
-#: apps/projects/templates/a4_candy_projects/project_list.html:18
-#: adhocracy-plus/templates/a4dashboard/project_list.html:27
-msgid "We could not find any projects."
-msgstr "Wir konnten keine Projekte finden."
 
 #: adhocracy4/dashboard/views.py:69
 msgid "Project successfully created."
@@ -546,56 +705,10 @@ msgstr "Positive Bewertungen"
 msgid "Negative ratings"
 msgstr "Negative Bewertungen"
 
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:5
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:23
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:35
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:47
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:59
-msgid "Export"
-msgstr "Export"
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:7
-msgid ""
-"You can export the results of your participation project as an excel file."
-msgstr ""
-"Sie können die Ergebnisse Ihres Beteiligungsprojektes als Excel-Datei "
-"exportieren."
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:19
-msgid "here you can export all ideas"
-msgstr "hier können Sie alle Ideen exportieren"
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:31
-msgid "here you can export all subjects"
-msgstr "hier können Sie alle Themen exportieren"
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:43
-msgid "here you can export all answers"
-msgstr "hier können Sie alle Antworten exportieren"
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:55
-msgid "here you can export all comments"
-msgstr "hier können Sie alle Kommentare exportieren"
-
 #: adhocracy4/forms/fields.py:18
 #, python-format
 msgid "Time of %(date_label)s"
 msgstr "Uhrzeit für %(date_label)s"
-
-#: adhocracy4/forms/templates/a4forms/includes/form_field.html:5
-#: apps/contrib/templates/a4_candy_contrib/includes/form_field.html:5
-#: adhocracy-plus/templates/account/signup.html:27
-#: adhocracy-plus/templates/account/signup.html:36
-#: adhocracy-plus/templates/socialaccount/signup.html:31
-msgid "This field is required"
-msgstr "Dieses Feld muss ausgefüllt werden"
-
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:14
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:15
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:18
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:19
-msgid "Remove category"
-msgstr "Kategorie entfernen"
 
 #: adhocracy4/images/fields.py:71
 #, python-brace-format
@@ -617,29 +730,6 @@ msgstr "{image_name} Urheber*in"
 #, python-brace-format
 msgid "Copyright shown in the {image_name}."
 msgstr "Urheber*in, die im {image_name} angezeigt wird."
-
-#: adhocracy4/images/templates/a4images/image_upload_widget.html:8
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:10
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:11
-msgid "Remove the picture"
-msgstr "Bild entfernen"
-
-#: adhocracy4/images/templates/a4images/image_upload_widget.html:12
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:16
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:17
-msgid "Upload a picture"
-msgstr "Bild hochladen"
-
-#: adhocracy4/images/templates/a4images/image_upload_widget.html:19
-msgid ""
-"\n"
-"            Your image will be uploaded/removed once you save your changes\n"
-"            at the end of this page.\n"
-"            "
-msgstr ""
-"\n"
-"Ihr Bild wird hochgeladen sobald Sie Ihre Änderungen am Ende der Seite "
-"speichern."
 
 #: adhocracy4/images/validators.py:21
 msgid "Unsupported file format. Supported formats are {}."
@@ -676,19 +766,6 @@ msgstr "Merkmale bearbeiten"
 #: adhocracy4/labels/forms.py:17
 msgid "Label"
 msgstr "Merkmal"
-
-#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
-msgid ""
-"In this section, you can create\n"
-"labels. If you create any, each contribution can be assigned\n"
-"to one or more of them. This way, content can be classified."
-msgstr ""
-"Hier können Sie Merkmale anlegen. Dadurch können alle Beiträge um ein oder "
-"mehrere Merkmale ergänzt werden."
-
-#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:21
-msgid "Add label"
-msgstr "Merkmal hinzufügen"
 
 #: adhocracy4/maps/admin.py:14
 #: adhocracy4/maps/models.py:11
@@ -919,24 +996,6 @@ msgstr "Beantworten Sie die Fragen und kommentieren Sie die Umfrage."
 #: adhocracy4/polls/phases.py:21
 msgid "polls"
 msgstr "Umfragen"
-
-#: adhocracy4/polls/templates/a4polls/poll_404.html:8
-msgid ""
-"Participation is not possible at the moment. The poll has not been set up "
-"yet."
-msgstr ""
-"Die Beteiligung ist aktuell noch nicht möglich. Die Umfrage wird gerade "
-"angelegt."
-
-#: adhocracy4/polls/templates/a4polls/poll_404.html:15
-msgid "Setup the poll by adding questions and answers in the dashboard."
-msgstr ""
-"Legen Sie die Umfrage an indem Sie Fragen und Antwortmöglichkeiten in der "
-"Projektverwaltung hinzufügen."
-
-#: adhocracy4/polls/templates/a4polls/poll_dashboard.html:5
-msgid "Edit poll"
-msgstr "Umfrage bearbeiten"
 
 #: adhocracy4/polls/validators.py:15
 #, python-format

--- a/locale-source/locale/de/LC_MESSAGES/djangojs.po
+++ b/locale-source/locale/de/LC_MESSAGES/djangojs.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-19 10:30+0200\n"
+"POT-Creation-Date: 2021-11-19 13:49+0100\n"
 "PO-Revision-Date: 2020-11-12 13:23+0000\n"
 "Last-Translator: Luca Thüer, 2021\n"
 "Language-Team: German (https://www.transifex.com/liqd/teams/109316/de/)\n"
@@ -24,21 +24,26 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:12
+#: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:12
 msgid "Insert Collapsible Item"
 msgstr "Aufklappbares Element einfügen"
 
+#: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:14
 #: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:14
 msgid "Title"
 msgstr "Titel"
 
 #: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:15
+#: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:15
 msgid "Body text"
 msgstr "Textkörper"
 
 #: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:37
+#: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:37
 msgid "Collapsible element"
 msgstr "Aufklappbares Element"
 
+#: adhocracy4/comments/static/comments/Comment.jsx:23
 #: adhocracy4/comments/static/comments/Comment.jsx:23
 #, javascript-format
 msgid "hide one reply"
@@ -47,6 +52,7 @@ msgstr[0] "Antwort ausblenden"
 msgstr[1] "%s Antworten ausblenden"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:25
+#: adhocracy4/comments/static/comments/Comment.jsx:25
 #, javascript-format
 msgid "view one reply"
 msgid_plural "view %s replies"
@@ -54,16 +60,22 @@ msgstr[0] "Antwort einblenden"
 msgstr[1] "%s Antworten einblenden"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:30
+#: adhocracy4/comments/static/comments/Comment.jsx:30
 msgid "Answer"
 msgstr "Antworten"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:31
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:418
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:420
+#: adhocracy4/comments/static/comments/Comment.jsx:31
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:420
 msgid "Your reply here"
 msgstr "Ihre Antwort hier"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:32
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:292
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:294
+#: adhocracy4/reports/static/reports/react_reports.jsx:20
+#: adhocracy4/comments/static/comments/Comment.jsx:32
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:294
 #: adhocracy4/reports/static/reports/react_reports.jsx:20
 msgid ""
 "You want to report this content? Your message will be sent to the "
@@ -75,15 +87,21 @@ msgstr ""
 "er nicht unseren Diskussionsregeln (Netiquette) entspricht."
 
 #: adhocracy4/comments/static/comments/Comment.jsx:96
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:269
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:271
+#: adhocracy4/comments/static/comments/Comment.jsx:96
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:271
 msgid "Moderator"
 msgstr "Moderation"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:105
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:264
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:266
+#: adhocracy4/comments/static/comments/Comment.jsx:105
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:266
 msgid "Latest edit on"
 msgstr "Letzte Änderung am"
 
+#: adhocracy4/comments/static/comments/Comment.jsx:110
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:260
 #: adhocracy4/comments/static/comments/Comment.jsx:110
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:260
 msgid "Deleted by creator on"
@@ -91,9 +109,13 @@ msgstr "Vom Ersteller gelöscht am"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:112
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:262
+#: adhocracy4/comments/static/comments/Comment.jsx:112
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:262
 msgid "Deleted by moderator on"
 msgstr "Von der Moderation gelöscht am"
 
+#: adhocracy4/comments/static/comments/Comment.jsx:151
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:241
 #: adhocracy4/comments/static/comments/Comment.jsx:151
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:241
 msgid "Do you really want to delete this comment?"
@@ -107,6 +129,10 @@ msgstr "Möchten Sie diesen Kommentar wirklich löschen?"
 #: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:73
 #: adhocracy4/polls/assets/EditPollQuestion.jsx:152
 #: adhocracy4/polls/assets/EditPollQuestion.jsx:157
+#: adhocracy4/comments/static/comments/Comment.jsx:152
+#: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:7
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:243
+#: adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx:22
 #: apps/documents/assets/ChapterNavItem.jsx:56
 #: apps/documents/assets/ChapterNavItem.jsx:61
 #: apps/documents/assets/ParagraphForm.jsx:133
@@ -119,14 +145,21 @@ msgstr "Löschen"
 #: adhocracy4/comments_async/static/modals/modal.jsx:58
 #: adhocracy4/comments_async/static/modals/moderate_modal.jsx:54
 #: adhocracy4/static/Modal.jsx:59
+#: adhocracy4/comments/static/comments/Comment.jsx:153
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:244
+#: adhocracy4/comments_async/static/modals/modal.jsx:58
+#: adhocracy4/comments_async/static/modals/moderate_modal.jsx:54
 msgid "Abort"
 msgstr "Abbrechen"
 
 #: adhocracy4/comments/static/comments/CommentBox.jsx:165
 #: adhocracy4/comments/static/comments/CommentEditForm.jsx:34
+#: adhocracy4/comments/static/comments/CommentBox.jsx:165
+#: adhocracy4/comments/static/comments/CommentEditForm.jsx:34
 msgid "Your comment here"
 msgstr "Ihr Kommentar hier"
 
+#: adhocracy4/comments/static/comments/CommentBox.jsx:168
 #: adhocracy4/comments/static/comments/CommentBox.jsx:168
 msgid "comment"
 msgid_plural "comments"
@@ -136,9 +169,15 @@ msgstr[1] "Kommentare"
 #: adhocracy4/comments/static/comments/CommentEditForm.jsx:35
 #: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:76
 #: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:48
+#: adhocracy4/comments/static/comments/CommentEditForm.jsx:35
+#: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:76
+#: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:48
 msgid "save changes"
 msgstr "Änderungen speichern"
 
+#: adhocracy4/comments/static/comments/CommentEditForm.jsx:36
+#: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:79
+#: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:51
 #: adhocracy4/comments/static/comments/CommentEditForm.jsx:36
 #: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:79
 #: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:51
@@ -148,9 +187,14 @@ msgstr "Abbrechen"
 #: adhocracy4/comments/static/comments/CommentForm.jsx:37
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:107
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:108
+#: adhocracy4/comments/static/comments/CommentForm.jsx:37
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:107
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:108
 msgid "post"
 msgstr "Senden"
 
+#: adhocracy4/comments/static/comments/CommentForm.jsx:38
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:117
 #: adhocracy4/comments/static/comments/CommentForm.jsx:38
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:117
 msgid "Please login to comment"
@@ -158,9 +202,13 @@ msgstr "Bitte melden Sie sich zum Kommentieren an."
 
 #: adhocracy4/comments/static/comments/CommentForm.jsx:39
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:129
+#: adhocracy4/comments/static/comments/CommentForm.jsx:39
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:129
 msgid "The currently active phase doesn't allow to comment."
 msgstr "Die aktuell laufende Phase erlaubt keine Kommentare."
 
+#: adhocracy4/comments/static/comments/CommentForm.jsx:40
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:123
 #: adhocracy4/comments/static/comments/CommentForm.jsx:40
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:123
 msgid "Only invited users can actively participate."
@@ -168,41 +216,52 @@ msgstr "Nur eingeladene Nutzer*innen können sich aktiv beteiligen."
 
 #: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:6
 #: adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx:18
+#: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:6
+#: adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx:18
 msgid "Edit"
 msgstr "Bearbeiten"
 
+#: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:8
 #: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:8
 msgid "Report"
 msgstr "Melden"
 
 #: adhocracy4/comments_async/static/comments_async/category_list.jsx:6
+#: adhocracy4/comments_async/static/comments_async/category_list.jsx:6
 msgid "Choose categories for your comment"
 msgstr "Wähle mindestens eine Kategorie"
 
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:19
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:19
 msgid "Entry successfully created"
 msgstr "Beitrag erstellt"
 
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:20
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:20
 msgid "Read more..."
 msgstr "Weiterlesen..."
 
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:21
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:21
 msgid "Read less"
 msgstr "Weniger anzeigen"
 
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:22
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:22
 msgid "Share"
 msgstr "Teilen"
 
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:23
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:23
 msgid " Report"
 msgstr " Melden"
 
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:33
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:33
 msgid "hide comments"
 msgstr "Kommentare verbergen"
 
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:36
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:36
 #, javascript-format
 msgid "1 comment"
@@ -211,34 +270,47 @@ msgstr[0] "1 Kommentar"
 msgstr[1] "%s Kommentare"
 
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:39
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:39
 msgctxt "verb"
 msgid "Comment"
 msgstr "Kommentieren"
 
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:299
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:264
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:264
+msgid "Blocked by moderator on"
+msgstr ""
+
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:301
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:301
 msgid "Share link"
 msgstr "Link teilen"
 
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:339
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:341
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:341
 msgid "Categories: "
 msgstr "Kategorien: "
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:15
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:15
 msgid "Newest"
 msgstr "Neueste"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:16
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:16
 msgid "Most up votes"
 msgstr "Meiste Zustimmung"
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:17
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:17
 msgid "Most down votes"
 msgstr "Meiste Ablehnung"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:18
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:18
 msgid "Most answers"
 msgstr "Meiste Antworten"
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:19
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:19
 msgid "Last discussed"
 msgstr "Zuletzt diskutiert"
@@ -246,10 +318,18 @@ msgstr "Zuletzt diskutiert"
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:51
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:310
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:545
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:29
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:51
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:310
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:545
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_box.jsx:57
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:32
 msgid "all"
 msgstr "Alle"
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:503
+#: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:72
+#: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:44
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:96
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:503
 #: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:72
 #: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:44
@@ -259,21 +339,27 @@ msgstr "Beitrag verfassen"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:519
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:523
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:519
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:523
 msgid "Search contributions"
 msgstr "Beiträge durchsuchen"
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:521
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:521
 msgid "Clear search"
 msgstr "Suche aufheben"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:537
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:537
 msgid "display: "
 msgstr "anzeigen: "
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:566
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:566
 msgid "sorted by: "
 msgstr "sortiert nach: "
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:587
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:587
 msgid "entry"
 msgid_plural "entries"
@@ -281,48 +367,59 @@ msgstr[0] "Beitrag"
 msgstr[1] "Beiträge"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:591
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:591
 msgid "entry found for "
 msgid_plural "entries found for "
 msgstr[0] "Beitrag gefunden zu "
 msgstr[1] "Beiträge gefunden zu "
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:595
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:595
 msgid "Filters"
 msgstr "Filter"
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:595
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:595
 msgid "Show filters"
 msgstr "Filter anzeigen"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:598
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:598
 msgid "Hide Filters"
 msgstr "Filter ausblenden"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:598
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:598
 msgid "Hide filters"
 msgstr "Filter ausblenden"
 
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:104
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:104
 #: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_form.jsx:78
 msgid " characters"
 msgstr " Zeichen"
 
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:108
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:108
 msgid "Comment"
 msgstr "Kommentar"
 
+#: adhocracy4/comments_async/static/modals/moderate_modal.jsx:31
 #: adhocracy4/comments_async/static/modals/moderate_modal.jsx:31
 msgid "Recommend comment"
 msgstr "Kommentar empfehlen"
 
 #: adhocracy4/comments_async/static/modals/moderate_modal.jsx:35
+#: adhocracy4/comments_async/static/modals/moderate_modal.jsx:35
 msgid "Is recommended"
 msgstr "Wird empfohlen"
 
 #: adhocracy4/comments_async/static/modals/moderate_modal.jsx:53
+#: adhocracy4/comments_async/static/modals/moderate_modal.jsx:53
 msgid "Submit"
 msgstr "Einreichen"
 
+#: adhocracy4/comments_async/static/modals/report_modal.jsx:62
 #: adhocracy4/comments_async/static/modals/report_modal.jsx:62
 msgid ""
 "Thanks for the feedback. It will be checked by the moderators as soon as "
@@ -333,34 +430,44 @@ msgstr ""
 
 #: adhocracy4/comments_async/static/modals/report_modal.jsx:71
 #: adhocracy4/reports/static/reports/ReportModal.jsx:61
+#: adhocracy4/comments_async/static/modals/report_modal.jsx:71
+#: adhocracy4/reports/static/reports/ReportModal.jsx:61
 msgid "Your message"
 msgstr "Ihre Nachricht"
 
+#: adhocracy4/comments_async/static/modals/report_modal.jsx:84
+#: adhocracy4/reports/static/reports/ReportModal.jsx:62
 #: adhocracy4/comments_async/static/modals/report_modal.jsx:84
 #: adhocracy4/reports/static/reports/ReportModal.jsx:62
 msgid "Send Report"
 msgstr "Meldung senden"
 
 #: adhocracy4/comments_async/static/modals/url_modal.jsx:23
+#: adhocracy4/comments_async/static/modals/url_modal.jsx:23
 msgid "Copy"
 msgstr "Kopieren"
 
+#: adhocracy4/comments_async/static/modals/url_modal.jsx:24
 #: adhocracy4/comments_async/static/modals/url_modal.jsx:24
 msgid "Copied"
 msgstr "Kopiert"
 
 #: adhocracy4/follows/static/follows/FollowButton.jsx:27
+#: adhocracy4/follows/static/follows/FollowButton.jsx:27
 msgid "You will no longer be updated via email."
 msgstr "Sie werden nicht mehr via E-Mail auf dem Laufenden gehalten."
 
+#: adhocracy4/follows/static/follows/FollowButton.jsx:29
 #: adhocracy4/follows/static/follows/FollowButton.jsx:29
 msgid "You will be updated via email."
 msgstr "Sie werden via E-Mail auf dem Laufenden gehalten."
 
 #: adhocracy4/follows/static/follows/FollowButton.jsx:63
+#: adhocracy4/follows/static/follows/FollowButton.jsx:63
 msgid "Follow"
 msgstr "Folgen"
 
+#: adhocracy4/follows/static/follows/FollowButton.jsx:64
 #: adhocracy4/follows/static/follows/FollowButton.jsx:64
 msgid "Following"
 msgstr "Folge ich"
@@ -553,6 +660,7 @@ msgid "Your choice"
 msgstr "Ihre Wahl"
 
 #: adhocracy4/reports/static/reports/ReportModal.jsx:60
+#: adhocracy4/reports/static/reports/ReportModal.jsx:60
 msgid "Thank you! We are taking care of it."
 msgstr "Dankeschön! Wir werden uns darum kümmern."
 
@@ -666,7 +774,6 @@ msgstr ""
 "Klicken, um die Liste der markierten Fragen auf dem Bildschirm anzuzeigen"
 
 #: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_box.jsx:27
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_box.jsx:57
 msgid "select affiliation"
 msgstr "Zugehörigkeit auswählen"
 
@@ -690,15 +797,15 @@ msgstr "Filter"
 msgid "Click to view filters"
 msgstr "Zum Anzeigen der Filter klicken"
 
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:30
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:29
 msgid "Click to only display marked questions"
 msgstr "Klicken, um nur markierte Fragen anzuzeigen"
 
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:31
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:30
 msgid "Click to only display questions which are not hidden"
 msgstr "Klicken, um Fragen anzuzeigen die nicht verborgen sind"
 
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:32
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:31
 msgid "Click to order list by likes"
 msgstr "Klicken, um die Liste nach Unterstützung zu sortieren"
 

--- a/locale-source/locale/en/LC_MESSAGES/django.po
+++ b/locale-source/locale/en/LC_MESSAGES/django.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: adhocracy-plus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-19 10:30+0200\n"
+"POT-Creation-Date: 2021-11-19 13:49+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -17,27 +17,6 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
-
-#: adhocracy4/categories/dashboard.py:13 apps/exports/mixins.py:19
-msgid "Categories"
-msgstr "Categories"
-
-#: adhocracy4/categories/dashboard.py:15
-msgid "Edit categories"
-msgstr "Edit categories"
-
-#: adhocracy4/categories/fields.py:12 adhocracy4/categories/filters.py:16
-#: adhocracy4/categories/forms.py:45 adhocracy4/exports/mixins/items.py:14
-msgid "Category"
-msgstr "Category"
-
-#: adhocracy4/categories/forms.py:38 adhocracy4/labels/forms.py:14
-msgid "Category name"
-msgstr "Category name"
-
-#: adhocracy4/categories/forms.py:39
-msgid "Category icon"
-msgstr "Category icon"
 
 #: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
 msgid ""
@@ -52,181 +31,6 @@ msgstr ""
 #: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:21
 msgid "Add category"
 msgstr "Add category"
-
-#: adhocracy4/comments/models.py:53 adhocracy4/polls/exports.py:41
-#: apps/budgeting/exports.py:75 apps/debate/exports.py:64
-#: apps/documents/exports.py:40 apps/ideas/exports.py:70
-#: apps/mapideas/exports.py:71 apps/topicprio/exports.py:68
-msgctxt "noun"
-msgid "Comment"
-msgstr "Comment"
-
-#: adhocracy4/comments/models.py:54 adhocracy4/exports/mixins/comments.py:46
-#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_list_item.html:16
-#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_list_item.html:17
-#: apps/ideas/templates/a4_candy_ideas/includes/idea_list_item.html:18
-#: apps/ideas/templates/a4_candy_ideas/includes/idea_list_item.html:19
-#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_list_item.html:18
-#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_list_item.html:20
-#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_list_item.html:18
-#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_list_item.html:20
-msgid "Comments"
-msgstr "Comments"
-
-#: adhocracy4/comments/serializers.py:52 adhocracy4/comments/serializers.py:151
-msgid "Please choose a category"
-msgstr "Please choose a category"
-
-#: adhocracy4/comments/serializers.py:61
-#: adhocracy4/comments_async/serializers.py:79
-msgid "unknown user"
-msgstr "unknown user"
-
-#: adhocracy4/comments_async/serializers.py:58
-msgid "Please choose one or more categories."
-msgstr "Please choose one or more categories."
-
-#: adhocracy4/dashboard/components/forms/views.py:22
-msgid "The project has been updated."
-msgstr "The project has been updated."
-
-#: adhocracy4/dashboard/components/forms/views.py:47
-msgid "The module has been updated."
-msgstr "The module has been updated."
-
-#: adhocracy4/dashboard/dashboard.py:13
-msgid "Basic settings"
-msgstr "Basic settings"
-
-#: adhocracy4/dashboard/dashboard.py:15
-msgid "Edit basic settings"
-msgstr "Edit basic settings"
-
-#: adhocracy4/dashboard/dashboard.py:23
-#: apps/organisations/templates/a4_candy_organisations/organisation_information.html:4
-#: apps/organisations/templates/a4_candy_organisations/organisation_information.html:18
-#: apps/projects/templates/a4_candy_projects/project_detail.html:82
-#: adhocracy-plus/templates/includes/project_header_mobile_toggle.html:23
-msgid "Information"
-msgstr "Information"
-
-#: adhocracy4/dashboard/dashboard.py:25
-msgid "Edit project information"
-msgstr "Edit project information"
-
-#: adhocracy4/dashboard/dashboard.py:33
-#: apps/projects/templates/a4_candy_projects/project_detail.html:102
-#: adhocracy-plus/templates/includes/project_header_mobile_toggle.html:41
-msgid "Result"
-msgstr "Result"
-
-#: adhocracy4/dashboard/dashboard.py:35
-msgid "Edit project result"
-msgstr "Edit project result"
-
-#: adhocracy4/dashboard/dashboard.py:43
-msgid "Basic information"
-msgstr "Basic information"
-
-#: adhocracy4/dashboard/dashboard.py:45
-msgid "Edit basic module information"
-msgstr "Edit basic module information"
-
-#: adhocracy4/dashboard/dashboard.py:53
-msgid "Phases"
-msgstr "Phases"
-
-#: adhocracy4/dashboard/dashboard.py:55
-msgid "Edit phases information"
-msgstr "Edit phases information"
-
-#: adhocracy4/dashboard/dashboard.py:64
-msgid "Areasettings"
-msgstr "Areasettings"
-
-#: adhocracy4/dashboard/dashboard.py:65
-msgid "Edit areasettings"
-msgstr "Edit areasettings"
-
-#: adhocracy4/dashboard/filter.py:11
-#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html:15
-#: apps/debate/filters.py:12 apps/ideas/views.py:28 apps/topicprio/views.py:21
-#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:4
-#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:10
-#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:11
-msgid "Search"
-msgstr "Search"
-
-#: adhocracy4/dashboard/filter.py:15 apps/budgeting/views.py:26
-msgid "Archived"
-msgstr "Archived"
-
-#: adhocracy4/dashboard/filter.py:19 adhocracy4/filters/widgets.py:32
-#: apps/budgeting/views.py:30
-msgid "All"
-msgstr "All"
-
-#: adhocracy4/dashboard/filter.py:20 apps/budgeting/views.py:31
-msgid "No"
-msgstr "No"
-
-#: adhocracy4/dashboard/filter.py:21
-#: apps/budgeting/templates/a4_candy_budgeting/proposal_confirm_delete.html:14
-#: apps/budgeting/views.py:32
-#: apps/debate/templates/a4_candy_debate/subject_confirm_delete.html:12
-#: apps/ideas/templates/a4_candy_ideas/idea_confirm_delete.html:14
-#: apps/mapideas/templates/a4_candy_mapideas/mapidea_confirm_delete.html:14
-#: apps/offlineevents/templates/a4_candy_offlineevents/offlineevent_confirm_delete.html:12
-#: apps/topicprio/templates/a4_candy_topicprio/topic_confirm_delete.html:12
-msgid "Yes"
-msgstr "Yes"
-
-#: adhocracy4/dashboard/forms.py:76
-msgid "All users can participate (public)."
-msgstr "All users can participate (public)."
-
-#: adhocracy4/dashboard/forms.py:78
-msgid "Only invited users can participate (private)."
-msgstr "Only invited users can participate (private)."
-
-#: adhocracy4/dashboard/forms.py:86
-#: apps/projects/templates/a4_candy_projects/project_detail.html:129
-msgid "Contact for questions"
-msgstr "Contact for questions"
-
-#: adhocracy4/dashboard/forms.py:87
-msgid ""
-"Please name a contact person. The user will then know who is carrying out "
-"this project and to whom they can address possible questions. The contact "
-"person will be shown in the information tab on the project page."
-msgstr ""
-"Please name a contact person. The user will then know who is carrying out "
-"this project and to whom they can address possible questions. The contact "
-"person will be shown in the information tab on the project page."
-
-#: adhocracy4/dashboard/forms.py:92
-msgid "More contact possibilities"
-msgstr "More contact possibilities"
-
-#: adhocracy4/dashboard/forms.py:134 adhocracy4/phases/models.py:77
-msgid "End date"
-msgstr "End date"
-
-#: adhocracy4/dashboard/forms.py:134
-msgid "End time"
-msgstr "End time"
-
-#: adhocracy4/dashboard/forms.py:140 adhocracy4/phases/models.py:75
-msgid "Start date"
-msgstr "Start date"
-
-#: adhocracy4/dashboard/forms.py:140
-msgid "Start time"
-msgstr "Start time"
-
-#: adhocracy4/dashboard/mixins.py:207
-msgid "Project successfully duplicated."
-msgstr "Project successfully duplicated."
 
 #: adhocracy4/dashboard/templates/a4dashboard/base_dashboard.html:4
 #: adhocracy-plus/templates/a4dashboard/base_dashboard.html:51
@@ -413,6 +217,301 @@ msgstr "Duplicate"
 msgid "We could not find any projects."
 msgstr "We could not find any projects."
 
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:5
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:23
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:35
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:47
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:59
+msgid "Export"
+msgstr "Export"
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:7
+msgid ""
+"You can export the results of your participation project as an excel file."
+msgstr ""
+"You can export the results of your participation project as an excel file."
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:19
+msgid "here you can export all ideas"
+msgstr "here you can export all ideas"
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:31
+msgid "here you can export all subjects"
+msgstr "here you can export all subjects"
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:43
+msgid "here you can export all answers"
+msgstr "here you can export all answers"
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:55
+msgid "here you can export all comments"
+msgstr "here you can export all comments"
+
+#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html:15
+#: adhocracy4/dashboard/filter.py:11 apps/debate/filters.py:12
+#: apps/ideas/views.py:28 apps/topicprio/views.py:21
+#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:4
+#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:10
+#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:11
+msgid "Search"
+msgstr "Search"
+
+#: adhocracy4/forms/templates/a4forms/includes/form_field.html:5
+#: apps/contrib/templates/a4_candy_contrib/includes/form_field.html:5
+#: adhocracy-plus/templates/account/signup.html:27
+#: adhocracy-plus/templates/account/signup.html:36
+#: adhocracy-plus/templates/socialaccount/signup.html:31
+msgid "This field is required"
+msgstr "This field is required"
+
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:14
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:15
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:18
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:19
+msgid "Remove category"
+msgstr "Remove category"
+
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:8
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:10
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:11
+msgid "Remove the picture"
+msgstr "Remove the picture"
+
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:12
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:16
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:17
+msgid "Upload a picture"
+msgstr "Upload a picture"
+
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:19
+msgid ""
+"\n"
+"            Your image will be uploaded/removed once you save your changes\n"
+"            at the end of this page.\n"
+"            "
+msgstr ""
+"\n"
+"            Your image will be uploaded/removed once you save your changes\n"
+"            at the end of this page.\n"
+"            "
+
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
+msgid ""
+"In this section, you can create\n"
+"labels. If you create any, each contribution can be assigned\n"
+"to one or more of them. This way, content can be classified."
+msgstr ""
+"In this section, you can create\n"
+"labels. If you create any, each contribution can be assigned\n"
+"to one or more of them. This way, content can be classified."
+
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:21
+msgid "Add label"
+msgstr "Add label"
+
+#: adhocracy4/polls/templates/a4polls/poll_404.html:8
+msgid ""
+"Participation is not possible at the moment. The poll has not been set up "
+"yet."
+msgstr ""
+"Participation is not possible at the moment. The poll has not been set up "
+"yet."
+
+#: adhocracy4/polls/templates/a4polls/poll_404.html:15
+msgid "Setup the poll by adding questions and answers in the dashboard."
+msgstr "Setup the poll by adding questions and answers in the dashboard."
+
+#: adhocracy4/polls/templates/a4polls/poll_dashboard.html:5
+msgid "Edit poll"
+msgstr "Edit poll"
+
+#: adhocracy4/categories/dashboard.py:13 apps/exports/mixins.py:19
+msgid "Categories"
+msgstr "Categories"
+
+#: adhocracy4/categories/dashboard.py:15
+msgid "Edit categories"
+msgstr "Edit categories"
+
+#: adhocracy4/categories/fields.py:12 adhocracy4/categories/filters.py:16
+#: adhocracy4/categories/forms.py:45 adhocracy4/exports/mixins/items.py:14
+msgid "Category"
+msgstr "Category"
+
+#: adhocracy4/categories/forms.py:38 adhocracy4/labels/forms.py:14
+msgid "Category name"
+msgstr "Category name"
+
+#: adhocracy4/categories/forms.py:39
+msgid "Category icon"
+msgstr "Category icon"
+
+#: adhocracy4/comments/models.py:54 adhocracy4/polls/exports.py:41
+#: apps/budgeting/exports.py:75 apps/debate/exports.py:64
+#: apps/documents/exports.py:40 apps/ideas/exports.py:70
+#: apps/mapideas/exports.py:71 apps/topicprio/exports.py:68
+msgctxt "noun"
+msgid "Comment"
+msgstr "Comment"
+
+#: adhocracy4/comments/models.py:55 adhocracy4/exports/mixins/comments.py:46
+#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_list_item.html:16
+#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_list_item.html:17
+#: apps/ideas/templates/a4_candy_ideas/includes/idea_list_item.html:18
+#: apps/ideas/templates/a4_candy_ideas/includes/idea_list_item.html:19
+#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_list_item.html:18
+#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_list_item.html:20
+#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_list_item.html:18
+#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_list_item.html:20
+msgid "Comments"
+msgstr "Comments"
+
+#: adhocracy4/comments/serializers.py:73 adhocracy4/comments/serializers.py:175
+msgid "Please choose a category"
+msgstr "Please choose a category"
+
+#: adhocracy4/comments/serializers.py:82
+#: adhocracy4/comments_async/serializers.py:84
+msgid "unknown user"
+msgstr "unknown user"
+
+#: adhocracy4/comments_async/serializers.py:63
+msgid "Please choose one or more categories."
+msgstr "Please choose one or more categories."
+
+#: adhocracy4/dashboard/components/forms/views.py:22
+msgid "The project has been updated."
+msgstr "The project has been updated."
+
+#: adhocracy4/dashboard/components/forms/views.py:47
+msgid "The module has been updated."
+msgstr "The module has been updated."
+
+#: adhocracy4/dashboard/dashboard.py:13
+msgid "Basic settings"
+msgstr "Basic settings"
+
+#: adhocracy4/dashboard/dashboard.py:15
+msgid "Edit basic settings"
+msgstr "Edit basic settings"
+
+#: adhocracy4/dashboard/dashboard.py:23
+#: apps/organisations/templates/a4_candy_organisations/organisation_information.html:4
+#: apps/organisations/templates/a4_candy_organisations/organisation_information.html:18
+#: apps/projects/templates/a4_candy_projects/project_detail.html:82
+#: adhocracy-plus/templates/includes/project_header_mobile_toggle.html:23
+msgid "Information"
+msgstr "Information"
+
+#: adhocracy4/dashboard/dashboard.py:25
+msgid "Edit project information"
+msgstr "Edit project information"
+
+#: adhocracy4/dashboard/dashboard.py:33
+#: apps/projects/templates/a4_candy_projects/project_detail.html:102
+#: adhocracy-plus/templates/includes/project_header_mobile_toggle.html:41
+msgid "Result"
+msgstr "Result"
+
+#: adhocracy4/dashboard/dashboard.py:35
+msgid "Edit project result"
+msgstr "Edit project result"
+
+#: adhocracy4/dashboard/dashboard.py:43
+msgid "Basic information"
+msgstr "Basic information"
+
+#: adhocracy4/dashboard/dashboard.py:45
+msgid "Edit basic module information"
+msgstr "Edit basic module information"
+
+#: adhocracy4/dashboard/dashboard.py:53
+msgid "Phases"
+msgstr "Phases"
+
+#: adhocracy4/dashboard/dashboard.py:55
+msgid "Edit phases information"
+msgstr "Edit phases information"
+
+#: adhocracy4/dashboard/dashboard.py:64
+msgid "Areasettings"
+msgstr "Areasettings"
+
+#: adhocracy4/dashboard/dashboard.py:65
+msgid "Edit areasettings"
+msgstr "Edit areasettings"
+
+#: adhocracy4/dashboard/filter.py:15 apps/budgeting/views.py:26
+msgid "Archived"
+msgstr "Archived"
+
+#: adhocracy4/dashboard/filter.py:19 adhocracy4/filters/widgets.py:32
+#: apps/budgeting/views.py:30
+msgid "All"
+msgstr "All"
+
+#: adhocracy4/dashboard/filter.py:20 apps/budgeting/views.py:31
+msgid "No"
+msgstr "No"
+
+#: adhocracy4/dashboard/filter.py:21
+#: apps/budgeting/templates/a4_candy_budgeting/proposal_confirm_delete.html:14
+#: apps/budgeting/views.py:32
+#: apps/debate/templates/a4_candy_debate/subject_confirm_delete.html:12
+#: apps/ideas/templates/a4_candy_ideas/idea_confirm_delete.html:14
+#: apps/mapideas/templates/a4_candy_mapideas/mapidea_confirm_delete.html:14
+#: apps/offlineevents/templates/a4_candy_offlineevents/offlineevent_confirm_delete.html:12
+#: apps/topicprio/templates/a4_candy_topicprio/topic_confirm_delete.html:12
+msgid "Yes"
+msgstr "Yes"
+
+#: adhocracy4/dashboard/forms.py:76
+msgid "All users can participate (public)."
+msgstr "All users can participate (public)."
+
+#: adhocracy4/dashboard/forms.py:78
+msgid "Only invited users can participate (private)."
+msgstr "Only invited users can participate (private)."
+
+#: adhocracy4/dashboard/forms.py:86
+#: apps/projects/templates/a4_candy_projects/project_detail.html:129
+msgid "Contact for questions"
+msgstr "Contact for questions"
+
+#: adhocracy4/dashboard/forms.py:87
+msgid ""
+"Please name a contact person. The user will then know who is carrying out "
+"this project and to whom they can address possible questions. The contact "
+"person will be shown in the information tab on the project page."
+msgstr ""
+"Please name a contact person. The user will then know who is carrying out "
+"this project and to whom they can address possible questions. The contact "
+"person will be shown in the information tab on the project page."
+
+#: adhocracy4/dashboard/forms.py:92
+msgid "More contact possibilities"
+msgstr "More contact possibilities"
+
+#: adhocracy4/dashboard/forms.py:134 adhocracy4/phases/models.py:77
+msgid "End date"
+msgstr "End date"
+
+#: adhocracy4/dashboard/forms.py:134
+msgid "End time"
+msgstr "End time"
+
+#: adhocracy4/dashboard/forms.py:140 adhocracy4/phases/models.py:75
+msgid "Start date"
+msgstr "Start date"
+
+#: adhocracy4/dashboard/forms.py:140
+msgid "Start time"
+msgstr "Start time"
+
+#: adhocracy4/dashboard/mixins.py:207
+msgid "Project successfully duplicated."
+msgstr "Project successfully duplicated."
+
 #: adhocracy4/dashboard/views.py:69
 msgid "Project successfully created."
 msgstr "Project successfully created."
@@ -521,55 +620,10 @@ msgstr "Positive ratings"
 msgid "Negative ratings"
 msgstr "Negative ratings"
 
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:5
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:23
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:35
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:47
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:59
-msgid "Export"
-msgstr "Export"
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:7
-msgid ""
-"You can export the results of your participation project as an excel file."
-msgstr ""
-"You can export the results of your participation project as an excel file."
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:19
-msgid "here you can export all ideas"
-msgstr "here you can export all ideas"
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:31
-msgid "here you can export all subjects"
-msgstr "here you can export all subjects"
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:43
-msgid "here you can export all answers"
-msgstr "here you can export all answers"
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:55
-msgid "here you can export all comments"
-msgstr "here you can export all comments"
-
 #: adhocracy4/forms/fields.py:18
 #, python-format
 msgid "Time of %(date_label)s"
 msgstr "Time of %(date_label)s"
-
-#: adhocracy4/forms/templates/a4forms/includes/form_field.html:5
-#: apps/contrib/templates/a4_candy_contrib/includes/form_field.html:5
-#: adhocracy-plus/templates/account/signup.html:27
-#: adhocracy-plus/templates/account/signup.html:36
-#: adhocracy-plus/templates/socialaccount/signup.html:31
-msgid "This field is required"
-msgstr "This field is required"
-
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:14
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:15
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:18
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:19
-msgid "Remove category"
-msgstr "Remove category"
 
 #: adhocracy4/images/fields.py:71
 #, python-brace-format
@@ -591,30 +645,6 @@ msgstr "{image_name} copyright"
 #, python-brace-format
 msgid "Copyright shown in the {image_name}."
 msgstr "Copyright shown in the {image_name}."
-
-#: adhocracy4/images/templates/a4images/image_upload_widget.html:8
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:10
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:11
-msgid "Remove the picture"
-msgstr "Remove the picture"
-
-#: adhocracy4/images/templates/a4images/image_upload_widget.html:12
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:16
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:17
-msgid "Upload a picture"
-msgstr "Upload a picture"
-
-#: adhocracy4/images/templates/a4images/image_upload_widget.html:19
-msgid ""
-"\n"
-"            Your image will be uploaded/removed once you save your changes\n"
-"            at the end of this page.\n"
-"            "
-msgstr ""
-"\n"
-"            Your image will be uploaded/removed once you save your changes\n"
-"            at the end of this page.\n"
-"            "
 
 #: adhocracy4/images/validators.py:21
 msgid "Unsupported file format. Supported formats are {}."
@@ -651,20 +681,6 @@ msgstr "Edit labels"
 #: adhocracy4/labels/forms.py:17
 msgid "Label"
 msgstr "Label"
-
-#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
-msgid ""
-"In this section, you can create\n"
-"labels. If you create any, each contribution can be assigned\n"
-"to one or more of them. This way, content can be classified."
-msgstr ""
-"In this section, you can create\n"
-"labels. If you create any, each contribution can be assigned\n"
-"to one or more of them. This way, content can be classified."
-
-#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:21
-msgid "Add label"
-msgstr "Add label"
 
 #: adhocracy4/maps/admin.py:14 adhocracy4/maps/models.py:11
 msgid "Polygon"
@@ -874,22 +890,6 @@ msgstr "Answer the questions and comment on the poll."
 #: adhocracy4/polls/phases.py:21
 msgid "polls"
 msgstr "polls"
-
-#: adhocracy4/polls/templates/a4polls/poll_404.html:8
-msgid ""
-"Participation is not possible at the moment. The poll has not been set up "
-"yet."
-msgstr ""
-"Participation is not possible at the moment. The poll has not been set up "
-"yet."
-
-#: adhocracy4/polls/templates/a4polls/poll_404.html:15
-msgid "Setup the poll by adding questions and answers in the dashboard."
-msgstr "Setup the poll by adding questions and answers in the dashboard."
-
-#: adhocracy4/polls/templates/a4polls/poll_dashboard.html:5
-msgid "Edit poll"
-msgstr "Edit poll"
 
 #: adhocracy4/polls/validators.py:15
 #, python-format

--- a/locale-source/locale/en/LC_MESSAGES/djangojs.po
+++ b/locale-source/locale/en/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-19 10:30+0200\n"
+"POT-Creation-Date: 2021-11-19 13:49+0100\n"
 "PO-Revision-Date: YEAR-MO-DA HO:MI+ZONE\n"
 "Last-Translator: FULL NAME <EMAIL@ADDRESS>\n"
 "Language-Team: LANGUAGE <LL@li.org>\n"
@@ -53,12 +53,12 @@ msgid "Answer"
 msgstr "Answer"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:31
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:418
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:420
 msgid "Your reply here"
 msgstr "Your reply here"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:32
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:292
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:294
 #: adhocracy4/reports/static/reports/react_reports.jsx:20
 msgid ""
 "You want to report this content? Your message will be sent to the "
@@ -70,12 +70,12 @@ msgstr ""
 "will be deleted if it does not meet our discussion rules (netiquette)."
 
 #: adhocracy4/comments/static/comments/Comment.jsx:96
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:269
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:271
 msgid "Moderator"
 msgstr "Moderator"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:105
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:264
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:266
 msgid "Latest edit on"
 msgstr "Latest edit on"
 
@@ -210,11 +210,15 @@ msgctxt "verb"
 msgid "Comment"
 msgstr "Comment"
 
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:299
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:264
+msgid "Blocked by moderator on"
+msgstr "Blocked by moderator on"
+
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:301
 msgid "Share link"
 msgstr "Share link"
 
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:339
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:341
 msgid "Categories: "
 msgstr "Categories: "
 
@@ -241,7 +245,8 @@ msgstr "Last discussed"
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:51
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:310
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:545
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:29
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_box.jsx:57
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:32
 msgid "all"
 msgstr "all"
 
@@ -655,7 +660,6 @@ msgid "Click to view list of marked questions screen"
 msgstr "Click to view list of marked questions screen"
 
 #: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_box.jsx:27
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_box.jsx:57
 msgid "select affiliation"
 msgstr "select affiliation"
 
@@ -679,15 +683,15 @@ msgstr " Filters"
 msgid "Click to view filters"
 msgstr "Click to view filters"
 
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:30
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:29
 msgid "Click to only display marked questions"
 msgstr "Click to only display marked questions"
 
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:31
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:30
 msgid "Click to only display questions which are not hidden"
 msgstr "Click to only display questions which are not hidden"
 
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:32
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:31
 msgid "Click to order list by likes"
 msgstr "Click to order list by likes"
 

--- a/locale-source/locale/ky/LC_MESSAGES/django.po
+++ b/locale-source/locale/ky/LC_MESSAGES/django.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: adhocracy-plus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-19 10:30+0200\n"
+"POT-Creation-Date: 2021-11-19 13:49+0100\n"
 "PO-Revision-Date: 2020-11-12 13:23+0000\n"
 "Last-Translator: Luca Thüer, 2021\n"
 "Language-Team: Kyrgyz (https://www.transifex.com/liqd/teams/109316/ky/)\n"
@@ -23,6 +23,374 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
+
+#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
+#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
+msgid ""
+"In this section, you can create\n"
+"categories. If you create any, each contribution has to be assigned\n"
+"to one of them. This way, content can be classified."
+msgstr ""
+"Бул бөлүмдө Сиз жаңы категорияларды ачсаңыз болот\n"
+". Категорияларды ачууда ар бир салым\n"
+" бир категорияга киргизилиши керек. Ошентип, контентти жиктөөгө болот. "
+
+#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:21
+#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:21
+msgid "Add category"
+msgstr "Категорияны кошуу"
+
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard.html:4
+#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:51
+msgid "Dashboard"
+msgstr "Жеке кабинет"
+
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:5
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:5
+#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:24
+msgid "Project Settings"
+msgstr "Долбоордун тууралоосу"
+
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:15
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:33
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:15
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:33
+#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:49
+#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:103
+msgid "Missing fields for publication"
+msgstr "Жарыялоо үчүн тилкелер жок"
+
+#: adhocracy4/dashboard/templates/a4dashboard/base_form_module.html:18
+#: adhocracy4/dashboard/templates/a4dashboard/base_form_project.html:18
+#: adhocracy4/dashboard/templates/a4dashboard/base_form_module.html:18
+#: adhocracy4/dashboard/templates/a4dashboard/base_form_project.html:18
+#: apps/activities/templates/a4_candy_activities/activities_dashboard.html:17
+#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_form.html:30
+#: apps/budgeting/templates/a4_candy_budgeting/proposal_moderate_form.html:39
+#: apps/debate/templates/a4_candy_debate/includes/subject_form.html:11
+#: apps/ideas/templates/a4_candy_ideas/idea_moderate_form.html:44
+#: apps/ideas/templates/a4_candy_ideas/includes/idea_form.html:24
+#: apps/interactiveevents/templates/a4_candy_interactive_events/extrafields_dashboard_form.html:19
+#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_form.html:28
+#: apps/mapideas/templates/a4_candy_mapideas/mapidea_moderate_form.html:43
+#: apps/moderatorremark/templates/a4_candy_moderatorremark/includes/popover_remark.html:27
+#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_form.html:15
+#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_form.html:22
+#: adhocracy-plus/templates/a4dashboard/base_form_module.html:23
+#: adhocracy-plus/templates/a4dashboard/base_form_project.html:23
+msgid "Save"
+msgstr "Сактоо"
+
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:9
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:9
+#: adhocracy-plus/templates/a4dashboard/blueprint_list.html:4
+#: adhocracy-plus/templates/a4dashboard/project_list.html:13
+msgid "New Project"
+msgstr "Жаңы долбоор "
+
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:17
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:17
+msgid "Phase"
+msgstr "Фаза"
+
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:23
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:23
+#: adhocracy-plus/templates/a4dashboard/includes/blueprint_list_tile.html:15
+msgid "Select"
+msgstr "Тандоо"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/form_field.html:6
+#: adhocracy4/dashboard/templates/a4dashboard/includes/form_field.html:6
+msgid "Missing field for publication"
+msgstr "Жарыялоо үчүн тилке жок"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:39
+#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:39
+#: adhocracy-plus/templates/a4dashboard/includes/preview.html:7
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:34
+msgid "Preview"
+msgstr "Алдын ала карап чыгуу"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:9
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:41
+#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:9
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:41
+#: apps/contrib/templates/a4_candy_contrib/includes/map_filter_and_sort.html:8
+#: apps/contrib/templates/a4_candy_contrib/includes/map_filter_and_sort.html:14
+#: apps/debate/templates/a4_candy_debate/includes/subject_dashboard_list_item.html:14
+#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_list_item.html:15
+#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_dashboard_list_item.html:14
+#: adhocracy-plus/templates/a4dashboard/includes/preview.html:9
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:36
+msgid "View"
+msgstr "Карап чыгуу"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:16
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:16
+#, python-format
+msgid "%(value)s from %(max)s"
+msgstr "%(value)sден%(max)s"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:17
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:17
+msgid "required fields for publication"
+msgstr "жарыялоо үчүн милдеттүү тилкелер "
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:27
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:27
+#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:12
+#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:46
+msgid "Publish"
+msgstr "Жарыялоо "
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:31
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:31
+#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:19
+msgid "Unpublish"
+msgstr "Чыгарылган жарыяны өчүрүү"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:7
+msgid "Create project based on"
+msgstr "негизинде долбоорду түзүү"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:23
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:23
+#: adhocracy-plus/templates/a4dashboard/project_create_form.html:41
+msgid ""
+"After saving the draft project you can further customize and edit your "
+"project and eventually publish it."
+msgstr ""
+"Болжолдуу долбоорду сактагандан кийин Сиз долбооруңузду кошумча тууралап "
+"оңдосоңуз болот жана акыркы оңдолгон вариантын жарыяласаңыз болот. "
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:25
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:25
+#: adhocracy-plus/templates/a4dashboard/project_create_form.html:46
+msgid "Create draft"
+msgstr "Болжолдуу долбоорду түзүү"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:27
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:27
+#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_form.html:29
+#: apps/budgeting/templates/a4_candy_budgeting/proposal_confirm_delete.html:15
+#: apps/budgeting/templates/a4_candy_budgeting/proposal_moderate_form.html:38
+#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:40
+#: apps/debate/templates/a4_candy_debate/includes/subject_form.html:10
+#: apps/debate/templates/a4_candy_debate/subject_confirm_delete.html:15
+#: apps/embed/templates/a4_candy_embed/embed.html:47
+#: apps/ideas/templates/a4_candy_ideas/idea_confirm_delete.html:16
+#: apps/ideas/templates/a4_candy_ideas/idea_moderate_form.html:43
+#: apps/ideas/templates/a4_candy_ideas/includes/idea_form.html:23
+#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_form.html:27
+#: apps/mapideas/templates/a4_candy_mapideas/mapidea_confirm_delete.html:15
+#: apps/mapideas/templates/a4_candy_mapideas/mapidea_moderate_form.html:42
+#: apps/newsletters/templates/a4_candy_newsletters/restricted_newsletter_dashboard_form.html:29
+#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_form.html:14
+#: apps/offlineevents/templates/a4_candy_offlineevents/offlineevent_confirm_delete.html:15
+#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_form.html:21
+#: apps/topicprio/templates/a4_candy_topicprio/topic_confirm_delete.html:15
+#: adhocracy-plus/templates/a4dashboard/project_create_form.html:45
+msgid "Cancel"
+msgstr "Баш тартуу"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:7
+#: apps/projects/templates/a4_candy_projects/project_list.html:4
+#: adhocracy-plus/templates/a4dashboard/base_project_list.html:16
+#: adhocracy-plus/templates/a4dashboard/project_list.html:4
+#: adhocracy-plus/templates/a4dashboard/project_list.html:9
+msgid "Projects"
+msgstr "Долбоорлор"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:24
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:24
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:17
+msgid "Finished"
+msgstr "Аяктады"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:27
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:27
+#: adhocracy4/projects/enums.py:14
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:20
+msgid "semipublic"
+msgstr "аралаш"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:30
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:30
+#: adhocracy4/projects/enums.py:15
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:23
+msgid "private"
+msgstr "жеке"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:48
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:48
+#: apps/contrib/templates/a4_candy_contrib/item_detail.html:103
+#: apps/debate/templates/a4_candy_debate/includes/subject_dashboard_list_item.html:19
+#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_list_item.html:20
+#: apps/projects/templates/a4_candy_projects/project_detail.html:112
+#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_dashboard_list_item.html:19
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:42
+msgid "Edit"
+msgstr "Редакциялоо "
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:57
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:57
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:65
+msgid "Duplicate"
+msgstr "Көчүрүү "
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:65
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:65
+#: apps/projects/templates/a4_candy_projects/project_list.html:18
+#: adhocracy-plus/templates/a4dashboard/project_list.html:27
+msgid "We could not find any projects."
+msgstr "Биз бир да долбоорду таба алган жокпуз"
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:5
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:23
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:35
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:47
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:59
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:5
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:23
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:35
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:47
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:59
+msgid "Export"
+msgstr "Өткөрүү "
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:7
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:7
+msgid ""
+"You can export the results of your participation project as an excel file."
+msgstr ""
+"Сиздин катышуу долбооруңуздун жыйынтыктарын excel  файлы түрүндө  өткөрсөңүз "
+"болот. "
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:19
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:19
+msgid "here you can export all ideas"
+msgstr "бул жакта сиз бардык идеяларды өткөрө аласыз "
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:31
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:31
+msgid "here you can export all subjects"
+msgstr ""
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:43
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:43
+msgid "here you can export all answers"
+msgstr ""
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:55
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:55
+msgid "here you can export all comments"
+msgstr "бул жакта сиз бардык пикирлерди өткөрө аласыз "
+
+#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html:15
+#: adhocracy4/dashboard/filter.py:11
+#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html:15
+#: apps/debate/filters.py:12 apps/ideas/views.py:28 apps/topicprio/views.py:21
+#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:4
+#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:10
+#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:11
+msgid "Search"
+msgstr "Издөө"
+
+#: adhocracy4/forms/templates/a4forms/includes/form_field.html:5
+#: adhocracy4/forms/templates/a4forms/includes/form_field.html:5
+#: apps/contrib/templates/a4_candy_contrib/includes/form_field.html:5
+#: adhocracy-plus/templates/account/signup.html:27
+#: adhocracy-plus/templates/account/signup.html:36
+#: adhocracy-plus/templates/socialaccount/signup.html:31
+msgid "This field is required"
+msgstr "Бул тилкени сөзсүз толтуруу керек "
+
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:14
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:15
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:18
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:19
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:14
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:15
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:18
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:19
+msgid "Remove category"
+msgstr "Категорияны өчүрүү"
+
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:8
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:8
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:10
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:11
+msgid "Remove the picture"
+msgstr "Сүрөттү өчүрүү"
+
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:12
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:12
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:16
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:17
+msgid "Upload a picture"
+msgstr "Сүрөттү жүктөө "
+
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:19
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:19
+msgid ""
+"\n"
+"            Your image will be uploaded/removed once you save your changes\n"
+"            at the end of this page.\n"
+"            "
+msgstr ""
+"\n"
+"             Сиздин сүрөт жүктөлөт / өзгөртүүлөрдү сактагандан кийин "
+"өчүрүлдү \n"
+"             бул баракчанын аягында."
+
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
+msgid ""
+"In this section, you can create\n"
+"labels. If you create any, each contribution can be assigned\n"
+"to one or more of them. This way, content can be classified."
+msgstr ""
+"Бул бөлүмдө Сиз \n"
+"ярлыктарды жасасаңыз болот. Ярлыктарды жасоодо ар бир салым алардын \n"
+"бирине  же бир нечесине киргизилиши керек. Ошентип, контентти жиктөөгө "
+"болот. "
+
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:21
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:21
+msgid "Add label"
+msgstr "Ярлыкты кошуу"
+
+#: adhocracy4/polls/templates/a4polls/poll_404.html:8
+#: adhocracy4/polls/templates/a4polls/poll_404.html:8
+msgid ""
+"Participation is not possible at the moment. The poll has not been set up "
+"yet."
+msgstr "Азыркы учурда катышуу мүмкүн эмес. Сурамжылоо баштала элек. "
+
+#: adhocracy4/polls/templates/a4polls/poll_404.html:15
+#: adhocracy4/polls/templates/a4polls/poll_404.html:15
+msgid "Setup the poll by adding questions and answers in the dashboard."
+msgstr ""
+"Жеке кабинетте суроолорду жана жоопторду кошуу менен сурамжылоону "
+"тууралаңыз. "
+
+#: adhocracy4/polls/templates/a4polls/poll_dashboard.html:5
+#: adhocracy4/polls/templates/a4polls/poll_dashboard.html:5
+msgid "Edit poll"
+msgstr "Сурамжылоону оңдоо"
 
 #: adhocracy4/categories/dashboard.py:13
 #: apps/exports/mixins.py:19
@@ -49,21 +417,7 @@ msgstr "Категориянын аталышы"
 msgid "Category icon"
 msgstr "Категориянын сүрөтчөсү"
 
-#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
-msgid ""
-"In this section, you can create\n"
-"categories. If you create any, each contribution has to be assigned\n"
-"to one of them. This way, content can be classified."
-msgstr ""
-"Бул бөлүмдө Сиз жаңы категорияларды ачсаңыз болот\n"
-". Категорияларды ачууда ар бир салым\n"
-" бир категорияга киргизилиши керек. Ошентип, контентти жиктөөгө болот. "
-
-#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:21
-msgid "Add category"
-msgstr "Категорияны кошуу"
-
-#: adhocracy4/comments/models.py:53
+#: adhocracy4/comments/models.py:54
 #: adhocracy4/polls/exports.py:41
 #: apps/budgeting/exports.py:75 apps/debate/exports.py:64
 #: apps/documents/exports.py:40 apps/ideas/exports.py:70
@@ -72,7 +426,7 @@ msgctxt "noun"
 msgid "Comment"
 msgstr "Пикир "
 
-#: adhocracy4/comments/models.py:54
+#: adhocracy4/comments/models.py:55
 #: adhocracy4/exports/mixins/comments.py:46
 #: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_list_item.html:16
 #: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_list_item.html:17
@@ -85,17 +439,17 @@ msgstr "Пикир "
 msgid "Comments"
 msgstr "Пикирлер"
 
-#: adhocracy4/comments/serializers.py:52
-#: adhocracy4/comments/serializers.py:151
+#: adhocracy4/comments/serializers.py:73
+#: adhocracy4/comments/serializers.py:175
 msgid "Please choose a category"
 msgstr "Сураныч, категорияны тандаңыз"
 
-#: adhocracy4/comments/serializers.py:61
-#: adhocracy4/comments_async/serializers.py:79
+#: adhocracy4/comments/serializers.py:82
+#: adhocracy4/comments_async/serializers.py:84
 msgid "unknown user"
 msgstr "белгисиз колдонуучу "
 
-#: adhocracy4/comments_async/serializers.py:58
+#: adhocracy4/comments_async/serializers.py:63
 msgid "Please choose one or more categories."
 msgstr "Сураныч, бир же бир нече категорияны тандаңыз"
 
@@ -160,15 +514,6 @@ msgstr "Чагылдыруу бөлүгү"
 #: adhocracy4/dashboard/dashboard.py:65
 msgid "Edit areasettings"
 msgstr "Чагылдыруу бөлүгүн өзгөртүү "
-
-#: adhocracy4/dashboard/filter.py:11
-#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html:15
-#: apps/debate/filters.py:12 apps/ideas/views.py:28 apps/topicprio/views.py:21
-#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:4
-#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:10
-#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:11
-msgid "Search"
-msgstr "Издөө"
 
 #: adhocracy4/dashboard/filter.py:15
 #: apps/budgeting/views.py:26
@@ -246,191 +591,6 @@ msgstr "Башталуу убактысы"
 #: adhocracy4/dashboard/mixins.py:207
 msgid "Project successfully duplicated."
 msgstr "Долбоордун көчүрмөсү ийгиликтүү жасалды."
-
-#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard.html:4
-#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:51
-msgid "Dashboard"
-msgstr "Жеке кабинет"
-
-#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:5
-#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:24
-msgid "Project Settings"
-msgstr "Долбоордун тууралоосу"
-
-#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:15
-#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:33
-#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:49
-#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:103
-msgid "Missing fields for publication"
-msgstr "Жарыялоо үчүн тилкелер жок"
-
-#: adhocracy4/dashboard/templates/a4dashboard/base_form_module.html:18
-#: adhocracy4/dashboard/templates/a4dashboard/base_form_project.html:18
-#: apps/activities/templates/a4_candy_activities/activities_dashboard.html:17
-#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_form.html:30
-#: apps/budgeting/templates/a4_candy_budgeting/proposal_moderate_form.html:39
-#: apps/debate/templates/a4_candy_debate/includes/subject_form.html:11
-#: apps/ideas/templates/a4_candy_ideas/idea_moderate_form.html:44
-#: apps/ideas/templates/a4_candy_ideas/includes/idea_form.html:24
-#: apps/interactiveevents/templates/a4_candy_interactive_events/extrafields_dashboard_form.html:19
-#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_form.html:28
-#: apps/mapideas/templates/a4_candy_mapideas/mapidea_moderate_form.html:43
-#: apps/moderatorremark/templates/a4_candy_moderatorremark/includes/popover_remark.html:27
-#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_form.html:15
-#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_form.html:22
-#: adhocracy-plus/templates/a4dashboard/base_form_module.html:23
-#: adhocracy-plus/templates/a4dashboard/base_form_project.html:23
-msgid "Save"
-msgstr "Сактоо"
-
-#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:4
-#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:7
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:9
-#: adhocracy-plus/templates/a4dashboard/blueprint_list.html:4
-#: adhocracy-plus/templates/a4dashboard/project_list.html:13
-msgid "New Project"
-msgstr "Жаңы долбоор "
-
-#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:17
-msgid "Phase"
-msgstr "Фаза"
-
-#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:23
-#: adhocracy-plus/templates/a4dashboard/includes/blueprint_list_tile.html:15
-msgid "Select"
-msgstr "Тандоо"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/form_field.html:6
-msgid "Missing field for publication"
-msgstr "Жарыялоо үчүн тилке жок"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:7
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:39
-#: adhocracy-plus/templates/a4dashboard/includes/preview.html:7
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:34
-msgid "Preview"
-msgstr "Алдын ала карап чыгуу"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:9
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:41
-#: apps/contrib/templates/a4_candy_contrib/includes/map_filter_and_sort.html:8
-#: apps/contrib/templates/a4_candy_contrib/includes/map_filter_and_sort.html:14
-#: apps/debate/templates/a4_candy_debate/includes/subject_dashboard_list_item.html:14
-#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_list_item.html:15
-#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_dashboard_list_item.html:14
-#: adhocracy-plus/templates/a4dashboard/includes/preview.html:9
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:36
-msgid "View"
-msgstr "Карап чыгуу"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:16
-#, python-format
-msgid "%(value)s from %(max)s"
-msgstr "%(value)sден%(max)s"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:17
-msgid "required fields for publication"
-msgstr "жарыялоо үчүн милдеттүү тилкелер "
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:27
-#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:12
-#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:46
-msgid "Publish"
-msgstr "Жарыялоо "
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:31
-#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:19
-msgid "Unpublish"
-msgstr "Чыгарылган жарыяны өчүрүү"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:4
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:7
-msgid "Create project based on"
-msgstr "негизинде долбоорду түзүү"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:23
-#: adhocracy-plus/templates/a4dashboard/project_create_form.html:41
-msgid ""
-"After saving the draft project you can further customize and edit your "
-"project and eventually publish it."
-msgstr ""
-"Болжолдуу долбоорду сактагандан кийин Сиз долбооруңузду кошумча тууралап "
-"оңдосоңуз болот жана акыркы оңдолгон вариантын жарыяласаңыз болот. "
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:25
-#: adhocracy-plus/templates/a4dashboard/project_create_form.html:46
-msgid "Create draft"
-msgstr "Болжолдуу долбоорду түзүү"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:27
-#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_form.html:29
-#: apps/budgeting/templates/a4_candy_budgeting/proposal_confirm_delete.html:15
-#: apps/budgeting/templates/a4_candy_budgeting/proposal_moderate_form.html:38
-#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:40
-#: apps/debate/templates/a4_candy_debate/includes/subject_form.html:10
-#: apps/debate/templates/a4_candy_debate/subject_confirm_delete.html:15
-#: apps/embed/templates/a4_candy_embed/embed.html:47
-#: apps/ideas/templates/a4_candy_ideas/idea_confirm_delete.html:16
-#: apps/ideas/templates/a4_candy_ideas/idea_moderate_form.html:43
-#: apps/ideas/templates/a4_candy_ideas/includes/idea_form.html:23
-#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_form.html:27
-#: apps/mapideas/templates/a4_candy_mapideas/mapidea_confirm_delete.html:15
-#: apps/mapideas/templates/a4_candy_mapideas/mapidea_moderate_form.html:42
-#: apps/newsletters/templates/a4_candy_newsletters/restricted_newsletter_dashboard_form.html:29
-#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_form.html:14
-#: apps/offlineevents/templates/a4_candy_offlineevents/offlineevent_confirm_delete.html:15
-#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_form.html:21
-#: apps/topicprio/templates/a4_candy_topicprio/topic_confirm_delete.html:15
-#: adhocracy-plus/templates/a4dashboard/project_create_form.html:45
-msgid "Cancel"
-msgstr "Баш тартуу"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:4
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:7
-#: apps/projects/templates/a4_candy_projects/project_list.html:4
-#: adhocracy-plus/templates/a4dashboard/base_project_list.html:16
-#: adhocracy-plus/templates/a4dashboard/project_list.html:4
-#: adhocracy-plus/templates/a4dashboard/project_list.html:9
-msgid "Projects"
-msgstr "Долбоорлор"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:24
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:17
-msgid "Finished"
-msgstr "Аяктады"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:27
-#: adhocracy4/projects/enums.py:14
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:20
-msgid "semipublic"
-msgstr "аралаш"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:30
-#: adhocracy4/projects/enums.py:15
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:23
-msgid "private"
-msgstr "жеке"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:48
-#: apps/contrib/templates/a4_candy_contrib/item_detail.html:103
-#: apps/debate/templates/a4_candy_debate/includes/subject_dashboard_list_item.html:19
-#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_list_item.html:20
-#: apps/projects/templates/a4_candy_projects/project_detail.html:112
-#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_dashboard_list_item.html:19
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:42
-msgid "Edit"
-msgstr "Редакциялоо "
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:57
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:65
-msgid "Duplicate"
-msgstr "Көчүрүү "
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:65
-#: apps/projects/templates/a4_candy_projects/project_list.html:18
-#: adhocracy-plus/templates/a4dashboard/project_list.html:27
-msgid "We could not find any projects."
-msgstr "Биз бир да долбоорду таба алган жокпуз"
 
 #: adhocracy4/dashboard/views.py:69
 msgid "Project successfully created."
@@ -544,56 +704,10 @@ msgstr "Оң рейтингдер "
 msgid "Negative ratings"
 msgstr "Терс рейтингдер "
 
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:5
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:23
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:35
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:47
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:59
-msgid "Export"
-msgstr "Өткөрүү "
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:7
-msgid ""
-"You can export the results of your participation project as an excel file."
-msgstr ""
-"Сиздин катышуу долбооруңуздун жыйынтыктарын excel  файлы түрүндө  өткөрсөңүз "
-"болот. "
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:19
-msgid "here you can export all ideas"
-msgstr "бул жакта сиз бардык идеяларды өткөрө аласыз "
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:31
-msgid "here you can export all subjects"
-msgstr ""
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:43
-msgid "here you can export all answers"
-msgstr ""
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:55
-msgid "here you can export all comments"
-msgstr "бул жакта сиз бардык пикирлерди өткөрө аласыз "
-
 #: adhocracy4/forms/fields.py:18
 #, python-format
 msgid "Time of %(date_label)s"
 msgstr "%(date_label)s убактысы"
-
-#: adhocracy4/forms/templates/a4forms/includes/form_field.html:5
-#: apps/contrib/templates/a4_candy_contrib/includes/form_field.html:5
-#: adhocracy-plus/templates/account/signup.html:27
-#: adhocracy-plus/templates/account/signup.html:36
-#: adhocracy-plus/templates/socialaccount/signup.html:31
-msgid "This field is required"
-msgstr "Бул тилкени сөзсүз толтуруу керек "
-
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:14
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:15
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:18
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:19
-msgid "Remove category"
-msgstr "Категорияны өчүрүү"
 
 #: adhocracy4/images/fields.py:71
 #, python-brace-format
@@ -616,30 +730,6 @@ msgstr "{image_name}автордук укук"
 #, python-brace-format
 msgid "Copyright shown in the {image_name}."
 msgstr "Автордук укук {image_name} жарыяланган "
-
-#: adhocracy4/images/templates/a4images/image_upload_widget.html:8
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:10
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:11
-msgid "Remove the picture"
-msgstr "Сүрөттү өчүрүү"
-
-#: adhocracy4/images/templates/a4images/image_upload_widget.html:12
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:16
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:17
-msgid "Upload a picture"
-msgstr "Сүрөттү жүктөө "
-
-#: adhocracy4/images/templates/a4images/image_upload_widget.html:19
-msgid ""
-"\n"
-"            Your image will be uploaded/removed once you save your changes\n"
-"            at the end of this page.\n"
-"            "
-msgstr ""
-"\n"
-"             Сиздин сүрөт жүктөлөт / өзгөртүүлөрдү сактагандан кийин "
-"өчүрүлдү \n"
-"             бул баракчанын аягында."
 
 #: adhocracy4/images/validators.py:21
 msgid "Unsupported file format. Supported formats are {}."
@@ -677,21 +767,6 @@ msgstr "Ярлыктарды оңдоо "
 #: adhocracy4/labels/forms.py:17
 msgid "Label"
 msgstr "Ярлык"
-
-#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
-msgid ""
-"In this section, you can create\n"
-"labels. If you create any, each contribution can be assigned\n"
-"to one or more of them. This way, content can be classified."
-msgstr ""
-"Бул бөлүмдө Сиз \n"
-"ярлыктарды жасасаңыз болот. Ярлыктарды жасоодо ар бир салым алардын \n"
-"бирине  же бир нечесине киргизилиши керек. Ошентип, контентти жиктөөгө "
-"болот. "
-
-#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:21
-msgid "Add label"
-msgstr "Ярлыкты кошуу"
 
 #: adhocracy4/maps/admin.py:14
 #: adhocracy4/maps/models.py:11
@@ -914,22 +989,6 @@ msgstr ""
 #: adhocracy4/polls/phases.py:21
 msgid "polls"
 msgstr "сурамжылоолор "
-
-#: adhocracy4/polls/templates/a4polls/poll_404.html:8
-msgid ""
-"Participation is not possible at the moment. The poll has not been set up "
-"yet."
-msgstr "Азыркы учурда катышуу мүмкүн эмес. Сурамжылоо баштала элек. "
-
-#: adhocracy4/polls/templates/a4polls/poll_404.html:15
-msgid "Setup the poll by adding questions and answers in the dashboard."
-msgstr ""
-"Жеке кабинетте суроолорду жана жоопторду кошуу менен сурамжылоону "
-"тууралаңыз. "
-
-#: adhocracy4/polls/templates/a4polls/poll_dashboard.html:5
-msgid "Edit poll"
-msgstr "Сурамжылоону оңдоо"
 
 #: adhocracy4/polls/validators.py:15
 #, python-format

--- a/locale-source/locale/ky/LC_MESSAGES/djangojs.po
+++ b/locale-source/locale/ky/LC_MESSAGES/djangojs.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-19 10:30+0200\n"
+"POT-Creation-Date: 2021-11-19 13:49+0100\n"
 "PO-Revision-Date: 2020-11-12 13:23+0000\n"
 "Last-Translator: Luca Thüer, 2021\n"
 "Language-Team: Kyrgyz (https://www.transifex.com/liqd/teams/109316/ky/)\n"
@@ -24,21 +24,26 @@ msgstr ""
 "Plural-Forms: nplurals=1; plural=0;\n"
 
 #: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:12
+#: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:12
 msgid "Insert Collapsible Item"
 msgstr "Ачылуучу пунктту кошуу"
 
+#: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:14
 #: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:14
 msgid "Title"
 msgstr "Аталышы"
 
 #: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:15
+#: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:15
 msgid "Body text"
 msgstr "Негизги текст"
 
 #: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:37
+#: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:37
 msgid "Collapsible element"
 msgstr "Ачылуучу пункт"
 
+#: adhocracy4/comments/static/comments/Comment.jsx:23
 #: adhocracy4/comments/static/comments/Comment.jsx:23
 #, javascript-format
 msgid "hide one reply"
@@ -46,22 +51,29 @@ msgid_plural "hide %s replies"
 msgstr[0] "%sжоопторду жашыруу"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:25
+#: adhocracy4/comments/static/comments/Comment.jsx:25
 #, javascript-format
 msgid "view one reply"
 msgid_plural "view %s replies"
 msgstr[0] "%sжоопторду карап чыгуу"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:30
+#: adhocracy4/comments/static/comments/Comment.jsx:30
 msgid "Answer"
 msgstr "Жооп берүү"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:31
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:418
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:420
+#: adhocracy4/comments/static/comments/Comment.jsx:31
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:420
 msgid "Your reply here"
 msgstr "Сиздин жообуңуз бул жакта"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:32
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:292
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:294
+#: adhocracy4/reports/static/reports/react_reports.jsx:20
+#: adhocracy4/comments/static/comments/Comment.jsx:32
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:294
 #: adhocracy4/reports/static/reports/react_reports.jsx:20
 msgid ""
 "You want to report this content? Your message will be sent to the "
@@ -73,15 +85,21 @@ msgstr ""
 "биздин талкуулоо эрежелерибизге (тармактык этикет) дал келбесе, өчүрүлөт. "
 
 #: adhocracy4/comments/static/comments/Comment.jsx:96
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:269
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:271
+#: adhocracy4/comments/static/comments/Comment.jsx:96
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:271
 msgid "Moderator"
 msgstr "Модератор"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:105
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:264
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:266
+#: adhocracy4/comments/static/comments/Comment.jsx:105
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:266
 msgid "Latest edit on"
 msgstr "-да акыркы өзгөрүү"
 
+#: adhocracy4/comments/static/comments/Comment.jsx:110
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:260
 #: adhocracy4/comments/static/comments/Comment.jsx:110
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:260
 msgid "Deleted by creator on"
@@ -89,9 +107,13 @@ msgstr ""
 
 #: adhocracy4/comments/static/comments/Comment.jsx:112
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:262
+#: adhocracy4/comments/static/comments/Comment.jsx:112
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:262
 msgid "Deleted by moderator on"
 msgstr ""
 
+#: adhocracy4/comments/static/comments/Comment.jsx:151
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:241
 #: adhocracy4/comments/static/comments/Comment.jsx:151
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:241
 msgid "Do you really want to delete this comment?"
@@ -105,6 +127,10 @@ msgstr "Бул пикирди чындыгында эле өчүрүүнү ка�
 #: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:73
 #: adhocracy4/polls/assets/EditPollQuestion.jsx:152
 #: adhocracy4/polls/assets/EditPollQuestion.jsx:157
+#: adhocracy4/comments/static/comments/Comment.jsx:152
+#: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:7
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:243
+#: adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx:22
 #: apps/documents/assets/ChapterNavItem.jsx:56
 #: apps/documents/assets/ChapterNavItem.jsx:61
 #: apps/documents/assets/ParagraphForm.jsx:133
@@ -117,19 +143,29 @@ msgstr "Өчүрүү"
 #: adhocracy4/comments_async/static/modals/modal.jsx:58
 #: adhocracy4/comments_async/static/modals/moderate_modal.jsx:54
 #: adhocracy4/static/Modal.jsx:59
+#: adhocracy4/comments/static/comments/Comment.jsx:153
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:244
+#: adhocracy4/comments_async/static/modals/modal.jsx:58
+#: adhocracy4/comments_async/static/modals/moderate_modal.jsx:54
 msgid "Abort"
 msgstr "баш тартуу"
 
+#: adhocracy4/comments/static/comments/CommentBox.jsx:165
+#: adhocracy4/comments/static/comments/CommentEditForm.jsx:34
 #: adhocracy4/comments/static/comments/CommentBox.jsx:165
 #: adhocracy4/comments/static/comments/CommentEditForm.jsx:34
 msgid "Your comment here"
 msgstr "Сиздин пикир бул жакта"
 
 #: adhocracy4/comments/static/comments/CommentBox.jsx:168
+#: adhocracy4/comments/static/comments/CommentBox.jsx:168
 msgid "comment"
 msgid_plural "comments"
 msgstr[0] "Пикирлер"
 
+#: adhocracy4/comments/static/comments/CommentEditForm.jsx:35
+#: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:76
+#: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:48
 #: adhocracy4/comments/static/comments/CommentEditForm.jsx:35
 #: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:76
 #: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:48
@@ -139,9 +175,15 @@ msgstr "Өзгөртүүлөрдү сактоо"
 #: adhocracy4/comments/static/comments/CommentEditForm.jsx:36
 #: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:79
 #: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:51
+#: adhocracy4/comments/static/comments/CommentEditForm.jsx:36
+#: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:79
+#: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:51
 msgid "cancel"
 msgstr "баш тартуу"
 
+#: adhocracy4/comments/static/comments/CommentForm.jsx:37
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:107
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:108
 #: adhocracy4/comments/static/comments/CommentForm.jsx:37
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:107
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:108
@@ -150,9 +192,13 @@ msgstr "билдирүү"
 
 #: adhocracy4/comments/static/comments/CommentForm.jsx:38
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:117
+#: adhocracy4/comments/static/comments/CommentForm.jsx:38
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:117
 msgid "Please login to comment"
 msgstr "Сураныч, пикир калтыруу үчүн кириңиз"
 
+#: adhocracy4/comments/static/comments/CommentForm.jsx:39
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:129
 #: adhocracy4/comments/static/comments/CommentForm.jsx:39
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:129
 msgid "The currently active phase doesn't allow to comment."
@@ -160,46 +206,59 @@ msgstr "Учурдагы активдүү фаза пикир калтырууг
 
 #: adhocracy4/comments/static/comments/CommentForm.jsx:40
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:123
+#: adhocracy4/comments/static/comments/CommentForm.jsx:40
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:123
 msgid "Only invited users can actively participate."
 msgstr "Чакырылган колдонуучулар гана активдүү катыша алат"
 
+#: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:6
+#: adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx:18
 #: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:6
 #: adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx:18
 msgid "Edit"
 msgstr "Оңдоо"
 
 #: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:8
+#: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:8
 msgid "Report"
 msgstr "Отчет"
 
+#: adhocracy4/comments_async/static/comments_async/category_list.jsx:6
 #: adhocracy4/comments_async/static/comments_async/category_list.jsx:6
 msgid "Choose categories for your comment"
 msgstr "Сиздин пикир үчүн категорияны тандаңыз"
 
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:19
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:19
 msgid "Entry successfully created"
 msgstr "Эсеп ийгиликтүү түзүлдү"
 
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:20
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:20
 msgid "Read more..."
 msgstr "Көбүрөөк окуу..."
 
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:21
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:21
 msgid "Read less"
 msgstr "Азыраак окуу..."
 
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:22
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:22
 msgid "Share"
 msgstr "Бөлүшүү"
 
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:23
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:23
 msgid " Report"
 msgstr "Отчет"
 
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:33
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:33
 msgid "hide comments"
 msgstr "пикирлерди жашыруу"
 
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:36
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:36
 #, javascript-format
 msgid "1 comment"
@@ -207,34 +266,47 @@ msgid_plural "%s comments"
 msgstr[0] "%sпикир"
 
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:39
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:39
 msgctxt "verb"
 msgid "Comment"
 msgstr "Пикир калтыруу"
 
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:299
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:264
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:264
+msgid "Blocked by moderator on"
+msgstr ""
+
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:301
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:301
 msgid "Share link"
 msgstr "Шилтеме менен бөлүшүү"
 
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:339
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:341
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:341
 msgid "Categories: "
 msgstr "Категориялар: "
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:15
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:15
 msgid "Newest"
 msgstr "Жаңылары"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:16
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:16
 msgid "Most up votes"
 msgstr "Добуштардын көпчүлүгү макул"
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:17
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:17
 msgid "Most down votes"
 msgstr "Добуштардын көпчүлүгү каршы"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:18
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:18
 msgid "Most answers"
 msgstr "Суроолордун көпчүлүгү"
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:19
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:19
 msgid "Last discussed"
 msgstr "Акыркы талкуу"
@@ -242,10 +314,18 @@ msgstr "Акыркы талкуу"
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:51
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:310
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:545
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:29
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:51
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:310
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:545
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_box.jsx:57
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:32
 msgid "all"
 msgstr "Баардыгы"
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:503
+#: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:72
+#: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:44
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:96
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:503
 #: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:72
 #: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:44
@@ -255,68 +335,85 @@ msgstr "Салымды  жазуу"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:519
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:523
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:519
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:523
 msgid "Search contributions"
 msgstr "Салым издөө"
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:521
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:521
 msgid "Clear search"
 msgstr "Издөөнү тазалоо"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:537
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:537
 msgid "display: "
 msgstr "Көрсөтүү: "
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:566
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:566
 msgid "sorted by: "
 msgstr "боюнча бөлүштүрүү"
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:587
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:587
 msgid "entry"
 msgid_plural "entries"
 msgstr[0] "Жазуулар"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:591
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:591
 msgid "entry found for "
 msgid_plural "entries found for "
 msgstr[0] "үчүн табылган жазуулар"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:595
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:595
 msgid "Filters"
 msgstr "Фильтрлер"
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:595
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:595
 msgid "Show filters"
 msgstr "Фильтрлерди көрсөтүү "
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:598
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:598
 msgid "Hide Filters"
 msgstr "Фильтрлерди жашыруу"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:598
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:598
 msgid "Hide filters"
 msgstr "Фильтрлерди жашыруу"
 
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:104
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:104
 #: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_form.jsx:78
 msgid " characters"
 msgstr "символдор"
 
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:108
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:108
 msgid "Comment"
 msgstr "Пикир калтыруу"
 
+#: adhocracy4/comments_async/static/modals/moderate_modal.jsx:31
 #: adhocracy4/comments_async/static/modals/moderate_modal.jsx:31
 msgid "Recommend comment"
 msgstr "Пикирди сунуштоо"
 
 #: adhocracy4/comments_async/static/modals/moderate_modal.jsx:35
+#: adhocracy4/comments_async/static/modals/moderate_modal.jsx:35
 msgid "Is recommended"
 msgstr "Сунушталды"
 
 #: adhocracy4/comments_async/static/modals/moderate_modal.jsx:53
+#: adhocracy4/comments_async/static/modals/moderate_modal.jsx:53
 msgid "Submit"
 msgstr "Тапшыруу"
 
+#: adhocracy4/comments_async/static/modals/report_modal.jsx:62
 #: adhocracy4/comments_async/static/modals/report_modal.jsx:62
 msgid ""
 "Thanks for the feedback. It will be checked by the moderators as soon as "
@@ -327,34 +424,44 @@ msgstr ""
 
 #: adhocracy4/comments_async/static/modals/report_modal.jsx:71
 #: adhocracy4/reports/static/reports/ReportModal.jsx:61
+#: adhocracy4/comments_async/static/modals/report_modal.jsx:71
+#: adhocracy4/reports/static/reports/ReportModal.jsx:61
 msgid "Your message"
 msgstr "Сиздин билдирүү"
 
+#: adhocracy4/comments_async/static/modals/report_modal.jsx:84
+#: adhocracy4/reports/static/reports/ReportModal.jsx:62
 #: adhocracy4/comments_async/static/modals/report_modal.jsx:84
 #: adhocracy4/reports/static/reports/ReportModal.jsx:62
 msgid "Send Report"
 msgstr "Отчетту жөнөтүү "
 
 #: adhocracy4/comments_async/static/modals/url_modal.jsx:23
+#: adhocracy4/comments_async/static/modals/url_modal.jsx:23
 msgid "Copy"
 msgstr "Көчүрүү"
 
+#: adhocracy4/comments_async/static/modals/url_modal.jsx:24
 #: adhocracy4/comments_async/static/modals/url_modal.jsx:24
 msgid "Copied"
 msgstr "Көчүрүлдү"
 
 #: adhocracy4/follows/static/follows/FollowButton.jsx:27
+#: adhocracy4/follows/static/follows/FollowButton.jsx:27
 msgid "You will no longer be updated via email."
 msgstr "Сиз мындан ары электрондук почта аркылуу жаңылоолорду албайсыз."
 
+#: adhocracy4/follows/static/follows/FollowButton.jsx:29
 #: adhocracy4/follows/static/follows/FollowButton.jsx:29
 msgid "You will be updated via email."
 msgstr "Сиз электрондук почта аркылуу жаңылоолорду алып турасыз. "
 
 #: adhocracy4/follows/static/follows/FollowButton.jsx:63
+#: adhocracy4/follows/static/follows/FollowButton.jsx:63
 msgid "Follow"
 msgstr "Катталуу"
 
+#: adhocracy4/follows/static/follows/FollowButton.jsx:64
 #: adhocracy4/follows/static/follows/FollowButton.jsx:64
 msgid "Following"
 msgstr "Катталган"
@@ -539,6 +646,7 @@ msgid "Your choice"
 msgstr "Сиздин тандоо"
 
 #: adhocracy4/reports/static/reports/ReportModal.jsx:60
+#: adhocracy4/reports/static/reports/ReportModal.jsx:60
 msgid "Thank you! We are taking care of it."
 msgstr "Ыракмат! Биз мунун үстүндө иштейбиз,"
 
@@ -651,7 +759,6 @@ msgid "Click to view list of marked questions screen"
 msgstr ""
 
 #: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_box.jsx:27
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_box.jsx:57
 msgid "select affiliation"
 msgstr "Таандыктыкты тандоо"
 
@@ -674,15 +781,15 @@ msgstr "Фильтрлер"
 msgid "Click to view filters"
 msgstr ""
 
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:30
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:29
 msgid "Click to only display marked questions"
 msgstr ""
 
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:31
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:30
 msgid "Click to only display questions which are not hidden"
 msgstr ""
 
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:32
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:31
 msgid "Click to order list by likes"
 msgstr ""
 

--- a/locale-source/locale/nl/LC_MESSAGES/django.po
+++ b/locale-source/locale/nl/LC_MESSAGES/django.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: adhocracy-plus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-19 10:30+0200\n"
+"POT-Creation-Date: 2021-11-19 13:49+0100\n"
 "PO-Revision-Date: 2020-11-12 13:23+0000\n"
 "Last-Translator: Joop Laan <joop@interconnecting.systems>, 2021\n"
 "Language-Team: Dutch (https://www.transifex.com/liqd/teams/109316/nl/)\n"
@@ -23,6 +23,373 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
+#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
+msgid ""
+"In this section, you can create\n"
+"categories. If you create any, each contribution has to be assigned\n"
+"to one of them. This way, content can be classified."
+msgstr ""
+"In deze sectie kunt u categorieën creëren. \n"
+"Als u een categorie aanmaakt, moet aan elke bijdrage een categorie\n"
+"worden toegewezen. Op deze manier kan de inhoud worden geclassificeerd."
+
+#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:21
+#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:21
+msgid "Add category"
+msgstr "Categorie toevoegen"
+
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard.html:4
+#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:51
+msgid "Dashboard"
+msgstr "Dashboard"
+
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:5
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:5
+#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:24
+msgid "Project Settings"
+msgstr "Projectinstellingen"
+
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:15
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:33
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:15
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:33
+#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:49
+#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:103
+msgid "Missing fields for publication"
+msgstr "Ontbrekende velden voor publicatie"
+
+#: adhocracy4/dashboard/templates/a4dashboard/base_form_module.html:18
+#: adhocracy4/dashboard/templates/a4dashboard/base_form_project.html:18
+#: adhocracy4/dashboard/templates/a4dashboard/base_form_module.html:18
+#: adhocracy4/dashboard/templates/a4dashboard/base_form_project.html:18
+#: apps/activities/templates/a4_candy_activities/activities_dashboard.html:17
+#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_form.html:30
+#: apps/budgeting/templates/a4_candy_budgeting/proposal_moderate_form.html:39
+#: apps/debate/templates/a4_candy_debate/includes/subject_form.html:11
+#: apps/ideas/templates/a4_candy_ideas/idea_moderate_form.html:44
+#: apps/ideas/templates/a4_candy_ideas/includes/idea_form.html:24
+#: apps/interactiveevents/templates/a4_candy_interactive_events/extrafields_dashboard_form.html:19
+#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_form.html:28
+#: apps/mapideas/templates/a4_candy_mapideas/mapidea_moderate_form.html:43
+#: apps/moderatorremark/templates/a4_candy_moderatorremark/includes/popover_remark.html:27
+#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_form.html:15
+#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_form.html:22
+#: adhocracy-plus/templates/a4dashboard/base_form_module.html:23
+#: adhocracy-plus/templates/a4dashboard/base_form_project.html:23
+msgid "Save"
+msgstr "Bewaren"
+
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:9
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:9
+#: adhocracy-plus/templates/a4dashboard/blueprint_list.html:4
+#: adhocracy-plus/templates/a4dashboard/project_list.html:13
+msgid "New Project"
+msgstr "Nieuw project"
+
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:17
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:17
+msgid "Phase"
+msgstr "Fase"
+
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:23
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:23
+#: adhocracy-plus/templates/a4dashboard/includes/blueprint_list_tile.html:15
+msgid "Select"
+msgstr "Selecteren"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/form_field.html:6
+#: adhocracy4/dashboard/templates/a4dashboard/includes/form_field.html:6
+msgid "Missing field for publication"
+msgstr "Ontbrekend veld voor publicatie"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:39
+#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:39
+#: adhocracy-plus/templates/a4dashboard/includes/preview.html:7
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:34
+msgid "Preview"
+msgstr "Voorbeeld"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:9
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:41
+#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:9
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:41
+#: apps/contrib/templates/a4_candy_contrib/includes/map_filter_and_sort.html:8
+#: apps/contrib/templates/a4_candy_contrib/includes/map_filter_and_sort.html:14
+#: apps/debate/templates/a4_candy_debate/includes/subject_dashboard_list_item.html:14
+#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_list_item.html:15
+#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_dashboard_list_item.html:14
+#: adhocracy-plus/templates/a4dashboard/includes/preview.html:9
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:36
+msgid "View"
+msgstr "Bekijk"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:16
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:16
+#, python-format
+msgid "%(value)s from %(max)s"
+msgstr "%(value)s van %(max)s"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:17
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:17
+msgid "required fields for publication"
+msgstr "verplichte velden voor publicatie"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:27
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:27
+#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:12
+#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:46
+msgid "Publish"
+msgstr "Publiceren"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:31
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:31
+#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:19
+msgid "Unpublish"
+msgstr "Publicatie ongedaan maken"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:7
+msgid "Create project based on"
+msgstr "Creëer project op basis van"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:23
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:23
+#: adhocracy-plus/templates/a4dashboard/project_create_form.html:41
+msgid ""
+"After saving the draft project you can further customize and edit your "
+"project and eventually publish it."
+msgstr ""
+"Na het opslaan van het concept project kunt u uw project verder aanpassen en "
+"bewerken en uiteindelijk publiceren."
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:25
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:25
+#: adhocracy-plus/templates/a4dashboard/project_create_form.html:46
+msgid "Create draft"
+msgstr "Aanmaken"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:27
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:27
+#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_form.html:29
+#: apps/budgeting/templates/a4_candy_budgeting/proposal_confirm_delete.html:15
+#: apps/budgeting/templates/a4_candy_budgeting/proposal_moderate_form.html:38
+#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:40
+#: apps/debate/templates/a4_candy_debate/includes/subject_form.html:10
+#: apps/debate/templates/a4_candy_debate/subject_confirm_delete.html:15
+#: apps/embed/templates/a4_candy_embed/embed.html:47
+#: apps/ideas/templates/a4_candy_ideas/idea_confirm_delete.html:16
+#: apps/ideas/templates/a4_candy_ideas/idea_moderate_form.html:43
+#: apps/ideas/templates/a4_candy_ideas/includes/idea_form.html:23
+#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_form.html:27
+#: apps/mapideas/templates/a4_candy_mapideas/mapidea_confirm_delete.html:15
+#: apps/mapideas/templates/a4_candy_mapideas/mapidea_moderate_form.html:42
+#: apps/newsletters/templates/a4_candy_newsletters/restricted_newsletter_dashboard_form.html:29
+#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_form.html:14
+#: apps/offlineevents/templates/a4_candy_offlineevents/offlineevent_confirm_delete.html:15
+#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_form.html:21
+#: apps/topicprio/templates/a4_candy_topicprio/topic_confirm_delete.html:15
+#: adhocracy-plus/templates/a4dashboard/project_create_form.html:45
+msgid "Cancel"
+msgstr "Annuleren"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:7
+#: apps/projects/templates/a4_candy_projects/project_list.html:4
+#: adhocracy-plus/templates/a4dashboard/base_project_list.html:16
+#: adhocracy-plus/templates/a4dashboard/project_list.html:4
+#: adhocracy-plus/templates/a4dashboard/project_list.html:9
+msgid "Projects"
+msgstr "Projecten"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:24
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:24
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:17
+msgid "Finished"
+msgstr "Beëindigd"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:27
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:27
+#: adhocracy4/projects/enums.py:14
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:20
+msgid "semipublic"
+msgstr "semi-publiek"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:30
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:30
+#: adhocracy4/projects/enums.py:15
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:23
+msgid "private"
+msgstr "privé"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:48
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:48
+#: apps/contrib/templates/a4_candy_contrib/item_detail.html:103
+#: apps/debate/templates/a4_candy_debate/includes/subject_dashboard_list_item.html:19
+#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_list_item.html:20
+#: apps/projects/templates/a4_candy_projects/project_detail.html:112
+#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_dashboard_list_item.html:19
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:42
+msgid "Edit"
+msgstr "Bewerken"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:57
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:57
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:65
+msgid "Duplicate"
+msgstr "Dupliceren"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:65
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:65
+#: apps/projects/templates/a4_candy_projects/project_list.html:18
+#: adhocracy-plus/templates/a4dashboard/project_list.html:27
+msgid "We could not find any projects."
+msgstr "We konden geen projecten vinden."
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:5
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:23
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:35
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:47
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:59
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:5
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:23
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:35
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:47
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:59
+msgid "Export"
+msgstr "Exporteren"
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:7
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:7
+msgid ""
+"You can export the results of your participation project as an excel file."
+msgstr ""
+"U kunt de resultaten van uw participatieproject als een excelbestand "
+"exporteren."
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:19
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:19
+msgid "here you can export all ideas"
+msgstr "hier kunt u alle ideeën exporteren"
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:31
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:31
+msgid "here you can export all subjects"
+msgstr "hier kunt u alle onderwerpen exporteren"
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:43
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:43
+msgid "here you can export all answers"
+msgstr "hier kunt u alle antwoorden exporteren"
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:55
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:55
+msgid "here you can export all comments"
+msgstr "hier kunt u alle opmerkingen exporteren"
+
+#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html:15
+#: adhocracy4/dashboard/filter.py:11
+#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html:15
+#: apps/debate/filters.py:12 apps/ideas/views.py:28 apps/topicprio/views.py:21
+#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:4
+#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:10
+#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:11
+msgid "Search"
+msgstr "Zoeken"
+
+#: adhocracy4/forms/templates/a4forms/includes/form_field.html:5
+#: adhocracy4/forms/templates/a4forms/includes/form_field.html:5
+#: apps/contrib/templates/a4_candy_contrib/includes/form_field.html:5
+#: adhocracy-plus/templates/account/signup.html:27
+#: adhocracy-plus/templates/account/signup.html:36
+#: adhocracy-plus/templates/socialaccount/signup.html:31
+msgid "This field is required"
+msgstr "Dit veld is verplicht"
+
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:14
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:15
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:18
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:19
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:14
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:15
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:18
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:19
+msgid "Remove category"
+msgstr "Categorie verwijderen"
+
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:8
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:8
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:10
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:11
+msgid "Remove the picture"
+msgstr "Verwijder de foto"
+
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:12
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:12
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:16
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:17
+msgid "Upload a picture"
+msgstr "Een foto uploaden"
+
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:19
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:19
+msgid ""
+"\n"
+"            Your image will be uploaded/removed once you save your changes\n"
+"            at the end of this page.\n"
+"            "
+msgstr ""
+"\n"
+"            Uw afbeelding wordt geüpload/verwijderd zodra u uw wijzigingen "
+"opslaat\n"
+"            aan het einde van deze pagina.\n"
+"            "
+
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
+msgid ""
+"In this section, you can create\n"
+"labels. If you create any, each contribution can be assigned\n"
+"to one or more of them. This way, content can be classified."
+msgstr ""
+"In deze sectie kunt u labels creëren. \n"
+"Als u een dergelijk label aanmaakt, kan elke bijdrage worden toegewezen\n"
+"aan een of meer van hen. Op deze manier kan de inhoud worden geclassificeerd."
+
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:21
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:21
+msgid "Add label"
+msgstr "Label toevoegen"
+
+#: adhocracy4/polls/templates/a4polls/poll_404.html:8
+#: adhocracy4/polls/templates/a4polls/poll_404.html:8
+msgid ""
+"Participation is not possible at the moment. The poll has not been set up "
+"yet."
+msgstr "Deelname is op dit moment niet mogelijk. De poll is nog niet opgezet."
+
+#: adhocracy4/polls/templates/a4polls/poll_404.html:15
+#: adhocracy4/polls/templates/a4polls/poll_404.html:15
+msgid "Setup the poll by adding questions and answers in the dashboard."
+msgstr ""
+"Stel de poll in door vragen en antwoorden in het dashboard toe te voegen."
+
+#: adhocracy4/polls/templates/a4polls/poll_dashboard.html:5
+#: adhocracy4/polls/templates/a4polls/poll_dashboard.html:5
+msgid "Edit poll"
+msgstr "Poll aanpassen"
 
 #: adhocracy4/categories/dashboard.py:13
 #: apps/exports/mixins.py:19
@@ -49,21 +416,7 @@ msgstr "Categorienaam"
 msgid "Category icon"
 msgstr "Categorie-icoon"
 
-#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
-msgid ""
-"In this section, you can create\n"
-"categories. If you create any, each contribution has to be assigned\n"
-"to one of them. This way, content can be classified."
-msgstr ""
-"In deze sectie kunt u categorieën creëren. \n"
-"Als u een categorie aanmaakt, moet aan elke bijdrage een categorie\n"
-"worden toegewezen. Op deze manier kan de inhoud worden geclassificeerd."
-
-#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:21
-msgid "Add category"
-msgstr "Categorie toevoegen"
-
-#: adhocracy4/comments/models.py:53
+#: adhocracy4/comments/models.py:54
 #: adhocracy4/polls/exports.py:41
 #: apps/budgeting/exports.py:75 apps/debate/exports.py:64
 #: apps/documents/exports.py:40 apps/ideas/exports.py:70
@@ -72,7 +425,7 @@ msgctxt "noun"
 msgid "Comment"
 msgstr "Reactie"
 
-#: adhocracy4/comments/models.py:54
+#: adhocracy4/comments/models.py:55
 #: adhocracy4/exports/mixins/comments.py:46
 #: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_list_item.html:16
 #: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_list_item.html:17
@@ -85,17 +438,17 @@ msgstr "Reactie"
 msgid "Comments"
 msgstr "Reacties"
 
-#: adhocracy4/comments/serializers.py:52
-#: adhocracy4/comments/serializers.py:151
+#: adhocracy4/comments/serializers.py:73
+#: adhocracy4/comments/serializers.py:175
 msgid "Please choose a category"
 msgstr "Kies een categorie"
 
-#: adhocracy4/comments/serializers.py:61
-#: adhocracy4/comments_async/serializers.py:79
+#: adhocracy4/comments/serializers.py:82
+#: adhocracy4/comments_async/serializers.py:84
 msgid "unknown user"
 msgstr "onbekende gebruiker"
 
-#: adhocracy4/comments_async/serializers.py:58
+#: adhocracy4/comments_async/serializers.py:63
 msgid "Please choose one or more categories."
 msgstr "Kies een of meer categorieën."
 
@@ -160,15 +513,6 @@ msgstr "Gebiedsinstellingen"
 #: adhocracy4/dashboard/dashboard.py:65
 msgid "Edit areasettings"
 msgstr "Gebiedsinstellingen bewerken"
-
-#: adhocracy4/dashboard/filter.py:11
-#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html:15
-#: apps/debate/filters.py:12 apps/ideas/views.py:28 apps/topicprio/views.py:21
-#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:4
-#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:10
-#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:11
-msgid "Search"
-msgstr "Zoeken"
 
 #: adhocracy4/dashboard/filter.py:15
 #: apps/budgeting/views.py:26
@@ -245,191 +589,6 @@ msgstr "Starttijd"
 #: adhocracy4/dashboard/mixins.py:207
 msgid "Project successfully duplicated."
 msgstr "Project succesvol gedupliceerd."
-
-#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard.html:4
-#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:51
-msgid "Dashboard"
-msgstr "Dashboard"
-
-#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:5
-#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:24
-msgid "Project Settings"
-msgstr "Projectinstellingen"
-
-#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:15
-#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:33
-#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:49
-#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:103
-msgid "Missing fields for publication"
-msgstr "Ontbrekende velden voor publicatie"
-
-#: adhocracy4/dashboard/templates/a4dashboard/base_form_module.html:18
-#: adhocracy4/dashboard/templates/a4dashboard/base_form_project.html:18
-#: apps/activities/templates/a4_candy_activities/activities_dashboard.html:17
-#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_form.html:30
-#: apps/budgeting/templates/a4_candy_budgeting/proposal_moderate_form.html:39
-#: apps/debate/templates/a4_candy_debate/includes/subject_form.html:11
-#: apps/ideas/templates/a4_candy_ideas/idea_moderate_form.html:44
-#: apps/ideas/templates/a4_candy_ideas/includes/idea_form.html:24
-#: apps/interactiveevents/templates/a4_candy_interactive_events/extrafields_dashboard_form.html:19
-#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_form.html:28
-#: apps/mapideas/templates/a4_candy_mapideas/mapidea_moderate_form.html:43
-#: apps/moderatorremark/templates/a4_candy_moderatorremark/includes/popover_remark.html:27
-#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_form.html:15
-#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_form.html:22
-#: adhocracy-plus/templates/a4dashboard/base_form_module.html:23
-#: adhocracy-plus/templates/a4dashboard/base_form_project.html:23
-msgid "Save"
-msgstr "Bewaren"
-
-#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:4
-#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:7
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:9
-#: adhocracy-plus/templates/a4dashboard/blueprint_list.html:4
-#: adhocracy-plus/templates/a4dashboard/project_list.html:13
-msgid "New Project"
-msgstr "Nieuw project"
-
-#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:17
-msgid "Phase"
-msgstr "Fase"
-
-#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:23
-#: adhocracy-plus/templates/a4dashboard/includes/blueprint_list_tile.html:15
-msgid "Select"
-msgstr "Selecteren"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/form_field.html:6
-msgid "Missing field for publication"
-msgstr "Ontbrekend veld voor publicatie"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:7
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:39
-#: adhocracy-plus/templates/a4dashboard/includes/preview.html:7
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:34
-msgid "Preview"
-msgstr "Voorbeeld"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:9
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:41
-#: apps/contrib/templates/a4_candy_contrib/includes/map_filter_and_sort.html:8
-#: apps/contrib/templates/a4_candy_contrib/includes/map_filter_and_sort.html:14
-#: apps/debate/templates/a4_candy_debate/includes/subject_dashboard_list_item.html:14
-#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_list_item.html:15
-#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_dashboard_list_item.html:14
-#: adhocracy-plus/templates/a4dashboard/includes/preview.html:9
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:36
-msgid "View"
-msgstr "Bekijk"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:16
-#, python-format
-msgid "%(value)s from %(max)s"
-msgstr "%(value)s van %(max)s"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:17
-msgid "required fields for publication"
-msgstr "verplichte velden voor publicatie"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:27
-#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:12
-#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:46
-msgid "Publish"
-msgstr "Publiceren"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:31
-#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:19
-msgid "Unpublish"
-msgstr "Publicatie ongedaan maken"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:4
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:7
-msgid "Create project based on"
-msgstr "Creëer project op basis van"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:23
-#: adhocracy-plus/templates/a4dashboard/project_create_form.html:41
-msgid ""
-"After saving the draft project you can further customize and edit your "
-"project and eventually publish it."
-msgstr ""
-"Na het opslaan van het concept project kunt u uw project verder aanpassen en "
-"bewerken en uiteindelijk publiceren."
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:25
-#: adhocracy-plus/templates/a4dashboard/project_create_form.html:46
-msgid "Create draft"
-msgstr "Aanmaken"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:27
-#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_form.html:29
-#: apps/budgeting/templates/a4_candy_budgeting/proposal_confirm_delete.html:15
-#: apps/budgeting/templates/a4_candy_budgeting/proposal_moderate_form.html:38
-#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:40
-#: apps/debate/templates/a4_candy_debate/includes/subject_form.html:10
-#: apps/debate/templates/a4_candy_debate/subject_confirm_delete.html:15
-#: apps/embed/templates/a4_candy_embed/embed.html:47
-#: apps/ideas/templates/a4_candy_ideas/idea_confirm_delete.html:16
-#: apps/ideas/templates/a4_candy_ideas/idea_moderate_form.html:43
-#: apps/ideas/templates/a4_candy_ideas/includes/idea_form.html:23
-#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_form.html:27
-#: apps/mapideas/templates/a4_candy_mapideas/mapidea_confirm_delete.html:15
-#: apps/mapideas/templates/a4_candy_mapideas/mapidea_moderate_form.html:42
-#: apps/newsletters/templates/a4_candy_newsletters/restricted_newsletter_dashboard_form.html:29
-#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_form.html:14
-#: apps/offlineevents/templates/a4_candy_offlineevents/offlineevent_confirm_delete.html:15
-#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_form.html:21
-#: apps/topicprio/templates/a4_candy_topicprio/topic_confirm_delete.html:15
-#: adhocracy-plus/templates/a4dashboard/project_create_form.html:45
-msgid "Cancel"
-msgstr "Annuleren"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:4
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:7
-#: apps/projects/templates/a4_candy_projects/project_list.html:4
-#: adhocracy-plus/templates/a4dashboard/base_project_list.html:16
-#: adhocracy-plus/templates/a4dashboard/project_list.html:4
-#: adhocracy-plus/templates/a4dashboard/project_list.html:9
-msgid "Projects"
-msgstr "Projecten"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:24
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:17
-msgid "Finished"
-msgstr "Beëindigd"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:27
-#: adhocracy4/projects/enums.py:14
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:20
-msgid "semipublic"
-msgstr "semi-publiek"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:30
-#: adhocracy4/projects/enums.py:15
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:23
-msgid "private"
-msgstr "privé"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:48
-#: apps/contrib/templates/a4_candy_contrib/item_detail.html:103
-#: apps/debate/templates/a4_candy_debate/includes/subject_dashboard_list_item.html:19
-#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_list_item.html:20
-#: apps/projects/templates/a4_candy_projects/project_detail.html:112
-#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_dashboard_list_item.html:19
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:42
-msgid "Edit"
-msgstr "Bewerken"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:57
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:65
-msgid "Duplicate"
-msgstr "Dupliceren"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:65
-#: apps/projects/templates/a4_candy_projects/project_list.html:18
-#: adhocracy-plus/templates/a4dashboard/project_list.html:27
-msgid "We could not find any projects."
-msgstr "We konden geen projecten vinden."
 
 #: adhocracy4/dashboard/views.py:69
 msgid "Project successfully created."
@@ -544,56 +703,10 @@ msgstr "Positieve beoordelingen"
 msgid "Negative ratings"
 msgstr "Negatieve beoordelingen"
 
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:5
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:23
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:35
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:47
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:59
-msgid "Export"
-msgstr "Exporteren"
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:7
-msgid ""
-"You can export the results of your participation project as an excel file."
-msgstr ""
-"U kunt de resultaten van uw participatieproject als een excelbestand "
-"exporteren."
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:19
-msgid "here you can export all ideas"
-msgstr "hier kunt u alle ideeën exporteren"
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:31
-msgid "here you can export all subjects"
-msgstr "hier kunt u alle onderwerpen exporteren"
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:43
-msgid "here you can export all answers"
-msgstr "hier kunt u alle antwoorden exporteren"
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:55
-msgid "here you can export all comments"
-msgstr "hier kunt u alle opmerkingen exporteren"
-
 #: adhocracy4/forms/fields.py:18
 #, python-format
 msgid "Time of %(date_label)s"
 msgstr "Tijdstip van %(date_label)s"
-
-#: adhocracy4/forms/templates/a4forms/includes/form_field.html:5
-#: apps/contrib/templates/a4_candy_contrib/includes/form_field.html:5
-#: adhocracy-plus/templates/account/signup.html:27
-#: adhocracy-plus/templates/account/signup.html:36
-#: adhocracy-plus/templates/socialaccount/signup.html:31
-msgid "This field is required"
-msgstr "Dit veld is verplicht"
-
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:14
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:15
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:18
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:19
-msgid "Remove category"
-msgstr "Categorie verwijderen"
 
 #: adhocracy4/images/fields.py:71
 #, python-brace-format
@@ -615,31 +728,6 @@ msgstr "{image_name} copyright"
 #, python-brace-format
 msgid "Copyright shown in the {image_name}."
 msgstr "Copyright weergegeven in de {image_name}."
-
-#: adhocracy4/images/templates/a4images/image_upload_widget.html:8
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:10
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:11
-msgid "Remove the picture"
-msgstr "Verwijder de foto"
-
-#: adhocracy4/images/templates/a4images/image_upload_widget.html:12
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:16
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:17
-msgid "Upload a picture"
-msgstr "Een foto uploaden"
-
-#: adhocracy4/images/templates/a4images/image_upload_widget.html:19
-msgid ""
-"\n"
-"            Your image will be uploaded/removed once you save your changes\n"
-"            at the end of this page.\n"
-"            "
-msgstr ""
-"\n"
-"            Uw afbeelding wordt geüpload/verwijderd zodra u uw wijzigingen "
-"opslaat\n"
-"            aan het einde van deze pagina.\n"
-"            "
 
 #: adhocracy4/images/validators.py:21
 msgid "Unsupported file format. Supported formats are {}."
@@ -676,20 +764,6 @@ msgstr "Labels bewerken"
 #: adhocracy4/labels/forms.py:17
 msgid "Label"
 msgstr "Label"
-
-#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
-msgid ""
-"In this section, you can create\n"
-"labels. If you create any, each contribution can be assigned\n"
-"to one or more of them. This way, content can be classified."
-msgstr ""
-"In deze sectie kunt u labels creëren. \n"
-"Als u een dergelijk label aanmaakt, kan elke bijdrage worden toegewezen\n"
-"aan een of meer van hen. Op deze manier kan de inhoud worden geclassificeerd."
-
-#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:21
-msgid "Add label"
-msgstr "Label toevoegen"
 
 #: adhocracy4/maps/admin.py:14
 #: adhocracy4/maps/models.py:11
@@ -917,21 +991,6 @@ msgstr "Beantwoord de vragen en reageer op de poll."
 #: adhocracy4/polls/phases.py:21
 msgid "polls"
 msgstr "polls"
-
-#: adhocracy4/polls/templates/a4polls/poll_404.html:8
-msgid ""
-"Participation is not possible at the moment. The poll has not been set up "
-"yet."
-msgstr "Deelname is op dit moment niet mogelijk. De poll is nog niet opgezet."
-
-#: adhocracy4/polls/templates/a4polls/poll_404.html:15
-msgid "Setup the poll by adding questions and answers in the dashboard."
-msgstr ""
-"Stel de poll in door vragen en antwoorden in het dashboard toe te voegen."
-
-#: adhocracy4/polls/templates/a4polls/poll_dashboard.html:5
-msgid "Edit poll"
-msgstr "Poll aanpassen"
 
 #: adhocracy4/polls/validators.py:15
 #, python-format

--- a/locale-source/locale/nl/LC_MESSAGES/djangojs.po
+++ b/locale-source/locale/nl/LC_MESSAGES/djangojs.po
@@ -12,7 +12,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-19 10:30+0200\n"
+"POT-Creation-Date: 2021-11-19 13:49+0100\n"
 "PO-Revision-Date: 2020-11-12 13:23+0000\n"
 "Last-Translator: Joop Laan <joop@interconnecting.systems>, 2021\n"
 "Language-Team: Dutch (https://www.transifex.com/liqd/teams/109316/nl/)\n"
@@ -23,21 +23,26 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:12
+#: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:12
 msgid "Insert Collapsible Item"
 msgstr "Uitklapbaar item toevoegen"
 
+#: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:14
 #: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:14
 msgid "Title"
 msgstr "Titel"
 
 #: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:15
+#: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:15
 msgid "Body text"
 msgstr "Beschrijving"
 
 #: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:37
+#: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:37
 msgid "Collapsible element"
 msgstr "Uitklapbaar element"
 
+#: adhocracy4/comments/static/comments/Comment.jsx:23
 #: adhocracy4/comments/static/comments/Comment.jsx:23
 #, javascript-format
 msgid "hide one reply"
@@ -46,6 +51,7 @@ msgstr[0] "één reactie verbergen"
 msgstr[1] "%s reacties verbergen"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:25
+#: adhocracy4/comments/static/comments/Comment.jsx:25
 #, javascript-format
 msgid "view one reply"
 msgid_plural "view %s replies"
@@ -53,16 +59,22 @@ msgstr[0] "één reactie bekijken"
 msgstr[1] "%s reacties bekijken"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:30
+#: adhocracy4/comments/static/comments/Comment.jsx:30
 msgid "Answer"
 msgstr "Antwoorden"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:31
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:418
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:420
+#: adhocracy4/comments/static/comments/Comment.jsx:31
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:420
 msgid "Your reply here"
 msgstr "Uw reactie hier"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:32
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:292
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:294
+#: adhocracy4/reports/static/reports/react_reports.jsx:20
+#: adhocracy4/comments/static/comments/Comment.jsx:32
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:294
 #: adhocracy4/reports/static/reports/react_reports.jsx:20
 msgid ""
 "You want to report this content? Your message will be sent to the "
@@ -74,15 +86,21 @@ msgstr ""
 "verwijderd als deze niet voldoet aan onze discussieregels (netiquette)."
 
 #: adhocracy4/comments/static/comments/Comment.jsx:96
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:269
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:271
+#: adhocracy4/comments/static/comments/Comment.jsx:96
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:271
 msgid "Moderator"
 msgstr "Moderator"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:105
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:264
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:266
+#: adhocracy4/comments/static/comments/Comment.jsx:105
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:266
 msgid "Latest edit on"
 msgstr "Laatste bewerking op"
 
+#: adhocracy4/comments/static/comments/Comment.jsx:110
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:260
 #: adhocracy4/comments/static/comments/Comment.jsx:110
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:260
 msgid "Deleted by creator on"
@@ -90,9 +108,13 @@ msgstr "Verwijderd door de auteur op"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:112
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:262
+#: adhocracy4/comments/static/comments/Comment.jsx:112
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:262
 msgid "Deleted by moderator on"
 msgstr "Verwijderd door moderator op"
 
+#: adhocracy4/comments/static/comments/Comment.jsx:151
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:241
 #: adhocracy4/comments/static/comments/Comment.jsx:151
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:241
 msgid "Do you really want to delete this comment?"
@@ -106,6 +128,10 @@ msgstr "Wilt u deze opmerking echt verwijderen?"
 #: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:73
 #: adhocracy4/polls/assets/EditPollQuestion.jsx:152
 #: adhocracy4/polls/assets/EditPollQuestion.jsx:157
+#: adhocracy4/comments/static/comments/Comment.jsx:152
+#: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:7
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:243
+#: adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx:22
 #: apps/documents/assets/ChapterNavItem.jsx:56
 #: apps/documents/assets/ChapterNavItem.jsx:61
 #: apps/documents/assets/ParagraphForm.jsx:133
@@ -118,14 +144,21 @@ msgstr "Verwijderen"
 #: adhocracy4/comments_async/static/modals/modal.jsx:58
 #: adhocracy4/comments_async/static/modals/moderate_modal.jsx:54
 #: adhocracy4/static/Modal.jsx:59
+#: adhocracy4/comments/static/comments/Comment.jsx:153
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:244
+#: adhocracy4/comments_async/static/modals/modal.jsx:58
+#: adhocracy4/comments_async/static/modals/moderate_modal.jsx:54
 msgid "Abort"
 msgstr "Afbreken"
 
 #: adhocracy4/comments/static/comments/CommentBox.jsx:165
 #: adhocracy4/comments/static/comments/CommentEditForm.jsx:34
+#: adhocracy4/comments/static/comments/CommentBox.jsx:165
+#: adhocracy4/comments/static/comments/CommentEditForm.jsx:34
 msgid "Your comment here"
 msgstr "Uw reactie hier"
 
+#: adhocracy4/comments/static/comments/CommentBox.jsx:168
 #: adhocracy4/comments/static/comments/CommentBox.jsx:168
 msgid "comment"
 msgid_plural "comments"
@@ -135,9 +168,15 @@ msgstr[1] "reacties"
 #: adhocracy4/comments/static/comments/CommentEditForm.jsx:35
 #: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:76
 #: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:48
+#: adhocracy4/comments/static/comments/CommentEditForm.jsx:35
+#: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:76
+#: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:48
 msgid "save changes"
 msgstr "bewaar wijzigingen"
 
+#: adhocracy4/comments/static/comments/CommentEditForm.jsx:36
+#: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:79
+#: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:51
 #: adhocracy4/comments/static/comments/CommentEditForm.jsx:36
 #: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:79
 #: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:51
@@ -147,9 +186,14 @@ msgstr "annuleren"
 #: adhocracy4/comments/static/comments/CommentForm.jsx:37
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:107
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:108
+#: adhocracy4/comments/static/comments/CommentForm.jsx:37
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:107
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:108
 msgid "post"
 msgstr "post"
 
+#: adhocracy4/comments/static/comments/CommentForm.jsx:38
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:117
 #: adhocracy4/comments/static/comments/CommentForm.jsx:38
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:117
 msgid "Please login to comment"
@@ -157,9 +201,13 @@ msgstr "Log in om een reactie te geven"
 
 #: adhocracy4/comments/static/comments/CommentForm.jsx:39
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:129
+#: adhocracy4/comments/static/comments/CommentForm.jsx:39
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:129
 msgid "The currently active phase doesn't allow to comment."
 msgstr "In de huidige actieve fase is het niet mogelijk om reactie te geven."
 
+#: adhocracy4/comments/static/comments/CommentForm.jsx:40
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:123
 #: adhocracy4/comments/static/comments/CommentForm.jsx:40
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:123
 msgid "Only invited users can actively participate."
@@ -167,41 +215,52 @@ msgstr "Alleen uitgenodigde gebruikers kunnen actief deelnemen."
 
 #: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:6
 #: adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx:18
+#: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:6
+#: adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx:18
 msgid "Edit"
 msgstr "Bewerken"
 
+#: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:8
 #: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:8
 msgid "Report"
 msgstr "Rapporteer"
 
 #: adhocracy4/comments_async/static/comments_async/category_list.jsx:6
+#: adhocracy4/comments_async/static/comments_async/category_list.jsx:6
 msgid "Choose categories for your comment"
 msgstr "Kies categorieën voor uw reactie"
 
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:19
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:19
 msgid "Entry successfully created"
 msgstr "Bijdrage succesvol gemaakt"
 
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:20
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:20
 msgid "Read more..."
 msgstr "Lees meer…"
 
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:21
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:21
 msgid "Read less"
 msgstr "Lees minder"
 
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:22
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:22
 msgid "Share"
 msgstr "Delen"
 
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:23
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:23
 msgid " Report"
 msgstr " Rapporteer"
 
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:33
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:33
 msgid "hide comments"
 msgstr "reacties verbergen"
 
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:36
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:36
 #, javascript-format
 msgid "1 comment"
@@ -210,34 +269,47 @@ msgstr[0] "1 reactie"
 msgstr[1] "%s reacties"
 
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:39
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:39
 msgctxt "verb"
 msgid "Comment"
 msgstr "Reageren"
 
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:299
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:264
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:264
+msgid "Blocked by moderator on"
+msgstr ""
+
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:301
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:301
 msgid "Share link"
 msgstr "Link delen"
 
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:339
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:341
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:341
 msgid "Categories: "
 msgstr "Categorieën: "
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:15
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:15
 msgid "Newest"
 msgstr "Nieuwste"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:16
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:16
 msgid "Most up votes"
 msgstr "Meeste up stemmen"
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:17
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:17
 msgid "Most down votes"
 msgstr "Meeste down stemmen"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:18
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:18
 msgid "Most answers"
 msgstr "Meeste antwoorden"
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:19
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:19
 msgid "Last discussed"
 msgstr "Laatst besproken"
@@ -245,10 +317,18 @@ msgstr "Laatst besproken"
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:51
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:310
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:545
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:29
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:51
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:310
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:545
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_box.jsx:57
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:32
 msgid "all"
 msgstr "allen"
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:503
+#: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:72
+#: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:44
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:96
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:503
 #: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:72
 #: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:44
@@ -258,21 +338,27 @@ msgstr "Bijdrage schrijven"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:519
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:523
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:519
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:523
 msgid "Search contributions"
 msgstr "Bijdragen zoeken"
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:521
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:521
 msgid "Clear search"
 msgstr "Zoek wissen"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:537
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:537
 msgid "display: "
 msgstr "weergave: "
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:566
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:566
 msgid "sorted by: "
 msgstr "gesorteerd op: "
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:587
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:587
 msgid "entry"
 msgid_plural "entries"
@@ -280,48 +366,59 @@ msgstr[0] "item"
 msgstr[1] "items"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:591
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:591
 msgid "entry found for "
 msgid_plural "entries found for "
 msgstr[0] "item gevonden voor "
 msgstr[1] "items gevonden voor "
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:595
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:595
 msgid "Filters"
 msgstr "Filters"
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:595
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:595
 msgid "Show filters"
 msgstr "Toon filters"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:598
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:598
 msgid "Hide Filters"
 msgstr "Verberg filters"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:598
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:598
 msgid "Hide filters"
 msgstr "Verberg filters"
 
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:104
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:104
 #: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_form.jsx:78
 msgid " characters"
 msgstr " karakters"
 
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:108
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:108
 msgid "Comment"
 msgstr "Reageren"
 
+#: adhocracy4/comments_async/static/modals/moderate_modal.jsx:31
 #: adhocracy4/comments_async/static/modals/moderate_modal.jsx:31
 msgid "Recommend comment"
 msgstr "Aanbevolen reactie"
 
 #: adhocracy4/comments_async/static/modals/moderate_modal.jsx:35
+#: adhocracy4/comments_async/static/modals/moderate_modal.jsx:35
 msgid "Is recommended"
 msgstr "Wordt aanbevolen"
 
 #: adhocracy4/comments_async/static/modals/moderate_modal.jsx:53
+#: adhocracy4/comments_async/static/modals/moderate_modal.jsx:53
 msgid "Submit"
 msgstr "Versturen"
 
+#: adhocracy4/comments_async/static/modals/report_modal.jsx:62
 #: adhocracy4/comments_async/static/modals/report_modal.jsx:62
 msgid ""
 "Thanks for the feedback. It will be checked by the moderators as soon as "
@@ -332,34 +429,44 @@ msgstr ""
 
 #: adhocracy4/comments_async/static/modals/report_modal.jsx:71
 #: adhocracy4/reports/static/reports/ReportModal.jsx:61
+#: adhocracy4/comments_async/static/modals/report_modal.jsx:71
+#: adhocracy4/reports/static/reports/ReportModal.jsx:61
 msgid "Your message"
 msgstr "Uw bericht"
 
+#: adhocracy4/comments_async/static/modals/report_modal.jsx:84
+#: adhocracy4/reports/static/reports/ReportModal.jsx:62
 #: adhocracy4/comments_async/static/modals/report_modal.jsx:84
 #: adhocracy4/reports/static/reports/ReportModal.jsx:62
 msgid "Send Report"
 msgstr "Raport versturen"
 
 #: adhocracy4/comments_async/static/modals/url_modal.jsx:23
+#: adhocracy4/comments_async/static/modals/url_modal.jsx:23
 msgid "Copy"
 msgstr "Kopieëren"
 
+#: adhocracy4/comments_async/static/modals/url_modal.jsx:24
 #: adhocracy4/comments_async/static/modals/url_modal.jsx:24
 msgid "Copied"
 msgstr "Gekopiëerd"
 
 #: adhocracy4/follows/static/follows/FollowButton.jsx:27
+#: adhocracy4/follows/static/follows/FollowButton.jsx:27
 msgid "You will no longer be updated via email."
 msgstr "U wordt niet meer geüpdatet via e-mail."
 
+#: adhocracy4/follows/static/follows/FollowButton.jsx:29
 #: adhocracy4/follows/static/follows/FollowButton.jsx:29
 msgid "You will be updated via email."
 msgstr "U wordt via e-mail op de hoogte gehouden."
 
 #: adhocracy4/follows/static/follows/FollowButton.jsx:63
+#: adhocracy4/follows/static/follows/FollowButton.jsx:63
 msgid "Follow"
 msgstr "Volgen"
 
+#: adhocracy4/follows/static/follows/FollowButton.jsx:64
 #: adhocracy4/follows/static/follows/FollowButton.jsx:64
 msgid "Following"
 msgstr "Volgend"
@@ -548,6 +655,7 @@ msgid "Your choice"
 msgstr "Uw keuze"
 
 #: adhocracy4/reports/static/reports/ReportModal.jsx:60
+#: adhocracy4/reports/static/reports/ReportModal.jsx:60
 msgid "Thank you! We are taking care of it."
 msgstr "Dank u wel! We zorgen ervoor."
 
@@ -660,7 +768,6 @@ msgid "Click to view list of marked questions screen"
 msgstr "Klik om de lijst van gemarkeerde vragen te bekijken"
 
 #: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_box.jsx:27
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_box.jsx:57
 msgid "select affiliation"
 msgstr "Groepering selecteren"
 
@@ -684,15 +791,15 @@ msgstr " Filters"
 msgid "Click to view filters"
 msgstr "Klik om filters te zien"
 
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:30
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:29
 msgid "Click to only display marked questions"
 msgstr "Klik om alleen gemarkeerde vragen weer te geven"
 
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:31
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:30
 msgid "Click to only display questions which are not hidden"
 msgstr "Klik om alleen vragen weer te geven die niet verborgen zijn"
 
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:32
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:31
 msgid "Click to order list by likes"
 msgstr "Klik om de lijst te rangschikken op vind-ik-leuks"
 

--- a/locale-source/locale/ru/LC_MESSAGES/django.po
+++ b/locale-source/locale/ru/LC_MESSAGES/django.po
@@ -14,7 +14,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: adhocracy-plus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-19 10:30+0200\n"
+"POT-Creation-Date: 2021-11-19 13:49+0100\n"
 "PO-Revision-Date: 2020-11-12 13:23+0000\n"
 "Last-Translator: Luca Thüer, 2021\n"
 "Language-Team: Russian (https://www.transifex.com/liqd/teams/109316/ru/)\n"
@@ -25,6 +25,373 @@ msgstr ""
 "Plural-Forms: nplurals=4; plural=(n%10==1 && n%100!=11 ? 0 : n%10>=2 && n"
 "%10<=4 && (n%100<12 || n%100>14) ? 1 : n%10==0 || (n%10>=5 && n%10<=9) || (n"
 "%100>=11 && n%100<=14)? 2 : 3);\n"
+
+#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
+#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
+msgid ""
+"In this section, you can create\n"
+"categories. If you create any, each contribution has to be assigned\n"
+"to one of them. This way, content can be classified."
+msgstr ""
+"В этом разделе вы можете создавать \n"
+"категории. Если вы их создаете, каждый вклад должен \n"
+"быть приписан к одной из категорий. Таким образом, контент можно "
+"классифицировать."
+
+#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:21
+#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:21
+msgid "Add category"
+msgstr "Добавить категорию"
+
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard.html:4
+#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:51
+msgid "Dashboard"
+msgstr "Личный кабинет"
+
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:5
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:5
+#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:24
+msgid "Project Settings"
+msgstr "Настройки проекта"
+
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:15
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:33
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:15
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:33
+#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:49
+#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:103
+msgid "Missing fields for publication"
+msgstr "Отсутствуют поля для публикации"
+
+#: adhocracy4/dashboard/templates/a4dashboard/base_form_module.html:18
+#: adhocracy4/dashboard/templates/a4dashboard/base_form_project.html:18
+#: adhocracy4/dashboard/templates/a4dashboard/base_form_module.html:18
+#: adhocracy4/dashboard/templates/a4dashboard/base_form_project.html:18
+#: apps/activities/templates/a4_candy_activities/activities_dashboard.html:17
+#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_form.html:30
+#: apps/budgeting/templates/a4_candy_budgeting/proposal_moderate_form.html:39
+#: apps/debate/templates/a4_candy_debate/includes/subject_form.html:11
+#: apps/ideas/templates/a4_candy_ideas/idea_moderate_form.html:44
+#: apps/ideas/templates/a4_candy_ideas/includes/idea_form.html:24
+#: apps/interactiveevents/templates/a4_candy_interactive_events/extrafields_dashboard_form.html:19
+#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_form.html:28
+#: apps/mapideas/templates/a4_candy_mapideas/mapidea_moderate_form.html:43
+#: apps/moderatorremark/templates/a4_candy_moderatorremark/includes/popover_remark.html:27
+#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_form.html:15
+#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_form.html:22
+#: adhocracy-plus/templates/a4dashboard/base_form_module.html:23
+#: adhocracy-plus/templates/a4dashboard/base_form_project.html:23
+msgid "Save"
+msgstr "Сохранить"
+
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:9
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:9
+#: adhocracy-plus/templates/a4dashboard/blueprint_list.html:4
+#: adhocracy-plus/templates/a4dashboard/project_list.html:13
+msgid "New Project"
+msgstr "Новый проект"
+
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:17
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:17
+msgid "Phase"
+msgstr "Фаза"
+
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:23
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:23
+#: adhocracy-plus/templates/a4dashboard/includes/blueprint_list_tile.html:15
+msgid "Select"
+msgstr "Выбрать"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/form_field.html:6
+#: adhocracy4/dashboard/templates/a4dashboard/includes/form_field.html:6
+msgid "Missing field for publication"
+msgstr "Отсутствует поле для публикации"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:39
+#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:39
+#: adhocracy-plus/templates/a4dashboard/includes/preview.html:7
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:34
+msgid "Preview"
+msgstr "Предварительный просмотр"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:9
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:41
+#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:9
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:41
+#: apps/contrib/templates/a4_candy_contrib/includes/map_filter_and_sort.html:8
+#: apps/contrib/templates/a4_candy_contrib/includes/map_filter_and_sort.html:14
+#: apps/debate/templates/a4_candy_debate/includes/subject_dashboard_list_item.html:14
+#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_list_item.html:15
+#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_dashboard_list_item.html:14
+#: adhocracy-plus/templates/a4dashboard/includes/preview.html:9
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:36
+msgid "View"
+msgstr "Просмотр"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:16
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:16
+#, python-format
+msgid "%(value)s from %(max)s"
+msgstr "%(value)sиз%(max)s"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:17
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:17
+msgid "required fields for publication"
+msgstr "обязательные поля для публикации"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:27
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:27
+#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:12
+#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:46
+msgid "Publish"
+msgstr "Опубликовать"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:31
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:31
+#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:19
+msgid "Unpublish"
+msgstr "Удалить публикацию"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:7
+msgid "Create project based on"
+msgstr "Создать проект на основе"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:23
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:23
+#: adhocracy-plus/templates/a4dashboard/project_create_form.html:41
+msgid ""
+"After saving the draft project you can further customize and edit your "
+"project and eventually publish it."
+msgstr ""
+"После сохранения предварительного проекта вы можете дополнительно настроить "
+"и отредактировать свой проект и опубликовать его в последней редакции."
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:25
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:25
+#: adhocracy-plus/templates/a4dashboard/project_create_form.html:46
+msgid "Create draft"
+msgstr "Создать предварительный проект"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:27
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:27
+#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_form.html:29
+#: apps/budgeting/templates/a4_candy_budgeting/proposal_confirm_delete.html:15
+#: apps/budgeting/templates/a4_candy_budgeting/proposal_moderate_form.html:38
+#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:40
+#: apps/debate/templates/a4_candy_debate/includes/subject_form.html:10
+#: apps/debate/templates/a4_candy_debate/subject_confirm_delete.html:15
+#: apps/embed/templates/a4_candy_embed/embed.html:47
+#: apps/ideas/templates/a4_candy_ideas/idea_confirm_delete.html:16
+#: apps/ideas/templates/a4_candy_ideas/idea_moderate_form.html:43
+#: apps/ideas/templates/a4_candy_ideas/includes/idea_form.html:23
+#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_form.html:27
+#: apps/mapideas/templates/a4_candy_mapideas/mapidea_confirm_delete.html:15
+#: apps/mapideas/templates/a4_candy_mapideas/mapidea_moderate_form.html:42
+#: apps/newsletters/templates/a4_candy_newsletters/restricted_newsletter_dashboard_form.html:29
+#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_form.html:14
+#: apps/offlineevents/templates/a4_candy_offlineevents/offlineevent_confirm_delete.html:15
+#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_form.html:21
+#: apps/topicprio/templates/a4_candy_topicprio/topic_confirm_delete.html:15
+#: adhocracy-plus/templates/a4dashboard/project_create_form.html:45
+msgid "Cancel"
+msgstr "Отмена"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:7
+#: apps/projects/templates/a4_candy_projects/project_list.html:4
+#: adhocracy-plus/templates/a4dashboard/base_project_list.html:16
+#: adhocracy-plus/templates/a4dashboard/project_list.html:4
+#: adhocracy-plus/templates/a4dashboard/project_list.html:9
+msgid "Projects"
+msgstr "Проекты"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:24
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:24
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:17
+msgid "Finished"
+msgstr "Завершено"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:27
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:27
+#: adhocracy4/projects/enums.py:14
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:20
+msgid "semipublic"
+msgstr "Смешанный"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:30
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:30
+#: adhocracy4/projects/enums.py:15
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:23
+msgid "private"
+msgstr "Частный"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:48
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:48
+#: apps/contrib/templates/a4_candy_contrib/item_detail.html:103
+#: apps/debate/templates/a4_candy_debate/includes/subject_dashboard_list_item.html:19
+#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_list_item.html:20
+#: apps/projects/templates/a4_candy_projects/project_detail.html:112
+#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_dashboard_list_item.html:19
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:42
+msgid "Edit"
+msgstr "Редактировать"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:57
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:57
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:65
+msgid "Duplicate"
+msgstr "Копировать"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:65
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:65
+#: apps/projects/templates/a4_candy_projects/project_list.html:18
+#: adhocracy-plus/templates/a4dashboard/project_list.html:27
+msgid "We could not find any projects."
+msgstr "Мы не смогли найти ни одного проекта"
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:5
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:23
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:35
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:47
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:59
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:5
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:23
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:35
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:47
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:59
+msgid "Export"
+msgstr "Экспорт"
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:7
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:7
+msgid ""
+"You can export the results of your participation project as an excel file."
+msgstr ""
+"Вы можете экспортировать результаты вашего проекта участия в виде файла "
+"Excel."
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:19
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:19
+msgid "here you can export all ideas"
+msgstr "здесь вы можете экспортировать все идеи"
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:31
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:31
+msgid "here you can export all subjects"
+msgstr ""
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:43
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:43
+msgid "here you can export all answers"
+msgstr ""
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:55
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:55
+msgid "here you can export all comments"
+msgstr "здесь вы можете экспортировать все комментарии"
+
+#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html:15
+#: adhocracy4/dashboard/filter.py:11
+#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html:15
+#: apps/debate/filters.py:12 apps/ideas/views.py:28 apps/topicprio/views.py:21
+#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:4
+#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:10
+#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:11
+msgid "Search"
+msgstr "Поиск"
+
+#: adhocracy4/forms/templates/a4forms/includes/form_field.html:5
+#: adhocracy4/forms/templates/a4forms/includes/form_field.html:5
+#: apps/contrib/templates/a4_candy_contrib/includes/form_field.html:5
+#: adhocracy-plus/templates/account/signup.html:27
+#: adhocracy-plus/templates/account/signup.html:36
+#: adhocracy-plus/templates/socialaccount/signup.html:31
+msgid "This field is required"
+msgstr "Это поле обязательно к заполнению"
+
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:14
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:15
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:18
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:19
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:14
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:15
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:18
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:19
+msgid "Remove category"
+msgstr "Удалить категорию"
+
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:8
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:8
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:10
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:11
+msgid "Remove the picture"
+msgstr "Удалить изображение"
+
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:12
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:12
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:16
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:17
+msgid "Upload a picture"
+msgstr "Загрузить изображение"
+
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:19
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:19
+msgid ""
+"\n"
+"            Your image will be uploaded/removed once you save your changes\n"
+"            at the end of this page.\n"
+"            "
+msgstr ""
+"\n"
+"          Ваше изображение будет загружено / удалено после сохранения "
+"изменений\n"
+"          в конце этой страницы."
+
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
+msgid ""
+"In this section, you can create\n"
+"labels. If you create any, each contribution can be assigned\n"
+"to one or more of them. This way, content can be classified."
+msgstr ""
+"В этом разделе вы можете создавать \n"
+"ярлыки. Если вы их создаете, каждый вклад может быть приписан \n"
+"к одному или нескольким из них. Таким образом, можно классифицировать "
+"контент."
+
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:21
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:21
+msgid "Add label"
+msgstr "Добавить ярлык"
+
+#: adhocracy4/polls/templates/a4polls/poll_404.html:8
+#: adhocracy4/polls/templates/a4polls/poll_404.html:8
+msgid ""
+"Participation is not possible at the moment. The poll has not been set up "
+"yet."
+msgstr "На данный момент участие невозможно. Опрос еще не настроен."
+
+#: adhocracy4/polls/templates/a4polls/poll_404.html:15
+#: adhocracy4/polls/templates/a4polls/poll_404.html:15
+msgid "Setup the poll by adding questions and answers in the dashboard."
+msgstr "Настройте опрос, добавив вопросы и ответы в личном кабинете."
+
+#: adhocracy4/polls/templates/a4polls/poll_dashboard.html:5
+#: adhocracy4/polls/templates/a4polls/poll_dashboard.html:5
+msgid "Edit poll"
+msgstr "Редактировать опрос"
 
 #: adhocracy4/categories/dashboard.py:13
 #: apps/exports/mixins.py:19
@@ -51,22 +418,7 @@ msgstr "Наименование категории"
 msgid "Category icon"
 msgstr "Иконка категории"
 
-#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
-msgid ""
-"In this section, you can create\n"
-"categories. If you create any, each contribution has to be assigned\n"
-"to one of them. This way, content can be classified."
-msgstr ""
-"В этом разделе вы можете создавать \n"
-"категории. Если вы их создаете, каждый вклад должен \n"
-"быть приписан к одной из категорий. Таким образом, контент можно "
-"классифицировать."
-
-#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:21
-msgid "Add category"
-msgstr "Добавить категорию"
-
-#: adhocracy4/comments/models.py:53
+#: adhocracy4/comments/models.py:54
 #: adhocracy4/polls/exports.py:41
 #: apps/budgeting/exports.py:75 apps/debate/exports.py:64
 #: apps/documents/exports.py:40 apps/ideas/exports.py:70
@@ -75,7 +427,7 @@ msgctxt "noun"
 msgid "Comment"
 msgstr "Комментарий"
 
-#: adhocracy4/comments/models.py:54
+#: adhocracy4/comments/models.py:55
 #: adhocracy4/exports/mixins/comments.py:46
 #: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_list_item.html:16
 #: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_list_item.html:17
@@ -88,17 +440,17 @@ msgstr "Комментарий"
 msgid "Comments"
 msgstr "Комментарии"
 
-#: adhocracy4/comments/serializers.py:52
-#: adhocracy4/comments/serializers.py:151
+#: adhocracy4/comments/serializers.py:73
+#: adhocracy4/comments/serializers.py:175
 msgid "Please choose a category"
 msgstr "Пожалуйста, выберите категорию"
 
-#: adhocracy4/comments/serializers.py:61
-#: adhocracy4/comments_async/serializers.py:79
+#: adhocracy4/comments/serializers.py:82
+#: adhocracy4/comments_async/serializers.py:84
 msgid "unknown user"
 msgstr "Неизвестный пользователь"
 
-#: adhocracy4/comments_async/serializers.py:58
+#: adhocracy4/comments_async/serializers.py:63
 msgid "Please choose one or more categories."
 msgstr "Выберите одну или несколько категорий"
 
@@ -163,15 +515,6 @@ msgstr "Область отображения"
 #: adhocracy4/dashboard/dashboard.py:65
 msgid "Edit areasettings"
 msgstr "Изменить область отображения"
-
-#: adhocracy4/dashboard/filter.py:11
-#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html:15
-#: apps/debate/filters.py:12 apps/ideas/views.py:28 apps/topicprio/views.py:21
-#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:4
-#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:10
-#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:11
-msgid "Search"
-msgstr "Поиск"
 
 #: adhocracy4/dashboard/filter.py:15
 #: apps/budgeting/views.py:26
@@ -248,191 +591,6 @@ msgstr "Время начала"
 #: adhocracy4/dashboard/mixins.py:207
 msgid "Project successfully duplicated."
 msgstr "Проект был успешно скопирован"
-
-#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard.html:4
-#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:51
-msgid "Dashboard"
-msgstr "Личный кабинет"
-
-#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:5
-#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:24
-msgid "Project Settings"
-msgstr "Настройки проекта"
-
-#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:15
-#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:33
-#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:49
-#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:103
-msgid "Missing fields for publication"
-msgstr "Отсутствуют поля для публикации"
-
-#: adhocracy4/dashboard/templates/a4dashboard/base_form_module.html:18
-#: adhocracy4/dashboard/templates/a4dashboard/base_form_project.html:18
-#: apps/activities/templates/a4_candy_activities/activities_dashboard.html:17
-#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_form.html:30
-#: apps/budgeting/templates/a4_candy_budgeting/proposal_moderate_form.html:39
-#: apps/debate/templates/a4_candy_debate/includes/subject_form.html:11
-#: apps/ideas/templates/a4_candy_ideas/idea_moderate_form.html:44
-#: apps/ideas/templates/a4_candy_ideas/includes/idea_form.html:24
-#: apps/interactiveevents/templates/a4_candy_interactive_events/extrafields_dashboard_form.html:19
-#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_form.html:28
-#: apps/mapideas/templates/a4_candy_mapideas/mapidea_moderate_form.html:43
-#: apps/moderatorremark/templates/a4_candy_moderatorremark/includes/popover_remark.html:27
-#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_form.html:15
-#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_form.html:22
-#: adhocracy-plus/templates/a4dashboard/base_form_module.html:23
-#: adhocracy-plus/templates/a4dashboard/base_form_project.html:23
-msgid "Save"
-msgstr "Сохранить"
-
-#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:4
-#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:7
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:9
-#: adhocracy-plus/templates/a4dashboard/blueprint_list.html:4
-#: adhocracy-plus/templates/a4dashboard/project_list.html:13
-msgid "New Project"
-msgstr "Новый проект"
-
-#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:17
-msgid "Phase"
-msgstr "Фаза"
-
-#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:23
-#: adhocracy-plus/templates/a4dashboard/includes/blueprint_list_tile.html:15
-msgid "Select"
-msgstr "Выбрать"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/form_field.html:6
-msgid "Missing field for publication"
-msgstr "Отсутствует поле для публикации"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:7
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:39
-#: adhocracy-plus/templates/a4dashboard/includes/preview.html:7
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:34
-msgid "Preview"
-msgstr "Предварительный просмотр"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:9
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:41
-#: apps/contrib/templates/a4_candy_contrib/includes/map_filter_and_sort.html:8
-#: apps/contrib/templates/a4_candy_contrib/includes/map_filter_and_sort.html:14
-#: apps/debate/templates/a4_candy_debate/includes/subject_dashboard_list_item.html:14
-#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_list_item.html:15
-#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_dashboard_list_item.html:14
-#: adhocracy-plus/templates/a4dashboard/includes/preview.html:9
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:36
-msgid "View"
-msgstr "Просмотр"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:16
-#, python-format
-msgid "%(value)s from %(max)s"
-msgstr "%(value)sиз%(max)s"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:17
-msgid "required fields for publication"
-msgstr "обязательные поля для публикации"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:27
-#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:12
-#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:46
-msgid "Publish"
-msgstr "Опубликовать"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:31
-#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:19
-msgid "Unpublish"
-msgstr "Удалить публикацию"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:4
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:7
-msgid "Create project based on"
-msgstr "Создать проект на основе"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:23
-#: adhocracy-plus/templates/a4dashboard/project_create_form.html:41
-msgid ""
-"After saving the draft project you can further customize and edit your "
-"project and eventually publish it."
-msgstr ""
-"После сохранения предварительного проекта вы можете дополнительно настроить "
-"и отредактировать свой проект и опубликовать его в последней редакции."
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:25
-#: adhocracy-plus/templates/a4dashboard/project_create_form.html:46
-msgid "Create draft"
-msgstr "Создать предварительный проект"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:27
-#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_form.html:29
-#: apps/budgeting/templates/a4_candy_budgeting/proposal_confirm_delete.html:15
-#: apps/budgeting/templates/a4_candy_budgeting/proposal_moderate_form.html:38
-#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:40
-#: apps/debate/templates/a4_candy_debate/includes/subject_form.html:10
-#: apps/debate/templates/a4_candy_debate/subject_confirm_delete.html:15
-#: apps/embed/templates/a4_candy_embed/embed.html:47
-#: apps/ideas/templates/a4_candy_ideas/idea_confirm_delete.html:16
-#: apps/ideas/templates/a4_candy_ideas/idea_moderate_form.html:43
-#: apps/ideas/templates/a4_candy_ideas/includes/idea_form.html:23
-#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_form.html:27
-#: apps/mapideas/templates/a4_candy_mapideas/mapidea_confirm_delete.html:15
-#: apps/mapideas/templates/a4_candy_mapideas/mapidea_moderate_form.html:42
-#: apps/newsletters/templates/a4_candy_newsletters/restricted_newsletter_dashboard_form.html:29
-#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_form.html:14
-#: apps/offlineevents/templates/a4_candy_offlineevents/offlineevent_confirm_delete.html:15
-#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_form.html:21
-#: apps/topicprio/templates/a4_candy_topicprio/topic_confirm_delete.html:15
-#: adhocracy-plus/templates/a4dashboard/project_create_form.html:45
-msgid "Cancel"
-msgstr "Отмена"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:4
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:7
-#: apps/projects/templates/a4_candy_projects/project_list.html:4
-#: adhocracy-plus/templates/a4dashboard/base_project_list.html:16
-#: adhocracy-plus/templates/a4dashboard/project_list.html:4
-#: adhocracy-plus/templates/a4dashboard/project_list.html:9
-msgid "Projects"
-msgstr "Проекты"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:24
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:17
-msgid "Finished"
-msgstr "Завершено"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:27
-#: adhocracy4/projects/enums.py:14
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:20
-msgid "semipublic"
-msgstr "Смешанный"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:30
-#: adhocracy4/projects/enums.py:15
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:23
-msgid "private"
-msgstr "Частный"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:48
-#: apps/contrib/templates/a4_candy_contrib/item_detail.html:103
-#: apps/debate/templates/a4_candy_debate/includes/subject_dashboard_list_item.html:19
-#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_list_item.html:20
-#: apps/projects/templates/a4_candy_projects/project_detail.html:112
-#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_dashboard_list_item.html:19
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:42
-msgid "Edit"
-msgstr "Редактировать"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:57
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:65
-msgid "Duplicate"
-msgstr "Копировать"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:65
-#: apps/projects/templates/a4_candy_projects/project_list.html:18
-#: adhocracy-plus/templates/a4dashboard/project_list.html:27
-msgid "We could not find any projects."
-msgstr "Мы не смогли найти ни одного проекта"
 
 #: adhocracy4/dashboard/views.py:69
 msgid "Project successfully created."
@@ -546,56 +704,10 @@ msgstr "Положительные рейтинги"
 msgid "Negative ratings"
 msgstr "Отрицательные рейтинги"
 
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:5
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:23
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:35
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:47
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:59
-msgid "Export"
-msgstr "Экспорт"
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:7
-msgid ""
-"You can export the results of your participation project as an excel file."
-msgstr ""
-"Вы можете экспортировать результаты вашего проекта участия в виде файла "
-"Excel."
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:19
-msgid "here you can export all ideas"
-msgstr "здесь вы можете экспортировать все идеи"
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:31
-msgid "here you can export all subjects"
-msgstr ""
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:43
-msgid "here you can export all answers"
-msgstr ""
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:55
-msgid "here you can export all comments"
-msgstr "здесь вы можете экспортировать все комментарии"
-
 #: adhocracy4/forms/fields.py:18
 #, python-format
 msgid "Time of %(date_label)s"
 msgstr "Время %(date_label)s"
-
-#: adhocracy4/forms/templates/a4forms/includes/form_field.html:5
-#: apps/contrib/templates/a4_candy_contrib/includes/form_field.html:5
-#: adhocracy-plus/templates/account/signup.html:27
-#: adhocracy-plus/templates/account/signup.html:36
-#: adhocracy-plus/templates/socialaccount/signup.html:31
-msgid "This field is required"
-msgstr "Это поле обязательно к заполнению"
-
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:14
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:15
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:18
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:19
-msgid "Remove category"
-msgstr "Удалить категорию"
 
 #: adhocracy4/images/fields.py:71
 #, python-brace-format
@@ -617,30 +729,6 @@ msgstr "{image_name}авторское право"
 #, python-brace-format
 msgid "Copyright shown in the {image_name}."
 msgstr "Авторское право отображено в {image_name}."
-
-#: adhocracy4/images/templates/a4images/image_upload_widget.html:8
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:10
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:11
-msgid "Remove the picture"
-msgstr "Удалить изображение"
-
-#: adhocracy4/images/templates/a4images/image_upload_widget.html:12
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:16
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:17
-msgid "Upload a picture"
-msgstr "Загрузить изображение"
-
-#: adhocracy4/images/templates/a4images/image_upload_widget.html:19
-msgid ""
-"\n"
-"            Your image will be uploaded/removed once you save your changes\n"
-"            at the end of this page.\n"
-"            "
-msgstr ""
-"\n"
-"          Ваше изображение будет загружено / удалено после сохранения "
-"изменений\n"
-"          в конце этой страницы."
 
 #: adhocracy4/images/validators.py:21
 msgid "Unsupported file format. Supported formats are {}."
@@ -678,21 +766,6 @@ msgstr "Редактировать ярлыки"
 #: adhocracy4/labels/forms.py:17
 msgid "Label"
 msgstr "Ярлык"
-
-#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
-msgid ""
-"In this section, you can create\n"
-"labels. If you create any, each contribution can be assigned\n"
-"to one or more of them. This way, content can be classified."
-msgstr ""
-"В этом разделе вы можете создавать \n"
-"ярлыки. Если вы их создаете, каждый вклад может быть приписан \n"
-"к одному или нескольким из них. Таким образом, можно классифицировать "
-"контент."
-
-#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:21
-msgid "Add label"
-msgstr "Добавить ярлык"
 
 #: adhocracy4/maps/admin.py:14
 #: adhocracy4/maps/models.py:11
@@ -915,20 +988,6 @@ msgstr ""
 #: adhocracy4/polls/phases.py:21
 msgid "polls"
 msgstr "Опросы"
-
-#: adhocracy4/polls/templates/a4polls/poll_404.html:8
-msgid ""
-"Participation is not possible at the moment. The poll has not been set up "
-"yet."
-msgstr "На данный момент участие невозможно. Опрос еще не настроен."
-
-#: adhocracy4/polls/templates/a4polls/poll_404.html:15
-msgid "Setup the poll by adding questions and answers in the dashboard."
-msgstr "Настройте опрос, добавив вопросы и ответы в личном кабинете."
-
-#: adhocracy4/polls/templates/a4polls/poll_dashboard.html:5
-msgid "Edit poll"
-msgstr "Редактировать опрос"
 
 #: adhocracy4/polls/validators.py:15
 #, python-format

--- a/locale-source/locale/ru/LC_MESSAGES/djangojs.po
+++ b/locale-source/locale/ru/LC_MESSAGES/djangojs.po
@@ -13,7 +13,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-19 10:30+0200\n"
+"POT-Creation-Date: 2021-11-19 13:49+0100\n"
 "PO-Revision-Date: 2020-11-12 13:23+0000\n"
 "Last-Translator: Luca Thüer, 2021\n"
 "Language-Team: Russian (https://www.transifex.com/liqd/teams/109316/ru/)\n"
@@ -26,21 +26,26 @@ msgstr ""
 "%100>=11 && n%100<=14)? 2 : 3);\n"
 
 #: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:12
+#: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:12
 msgid "Insert Collapsible Item"
 msgstr "Вставить разворачивающийся пункт"
 
+#: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:14
 #: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:14
 msgid "Title"
 msgstr "Заголовок"
 
 #: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:15
+#: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:15
 msgid "Body text"
 msgstr "Основной текст"
 
 #: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:37
+#: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:37
 msgid "Collapsible element"
 msgstr "Разворачивающийся пункт"
 
+#: adhocracy4/comments/static/comments/Comment.jsx:23
 #: adhocracy4/comments/static/comments/Comment.jsx:23
 #, javascript-format
 msgid "hide one reply"
@@ -51,6 +56,7 @@ msgstr[2] "скрыть %sответ"
 msgstr[3] "скрыть %sответов"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:25
+#: adhocracy4/comments/static/comments/Comment.jsx:25
 #, javascript-format
 msgid "view one reply"
 msgid_plural "view %s replies"
@@ -60,16 +66,22 @@ msgstr[2] "просмотреть %s ответов"
 msgstr[3] "просмотреть %s ответов"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:30
+#: adhocracy4/comments/static/comments/Comment.jsx:30
 msgid "Answer"
 msgstr "Ответить"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:31
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:418
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:420
+#: adhocracy4/comments/static/comments/Comment.jsx:31
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:420
 msgid "Your reply here"
 msgstr "Ваш ответ здесь"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:32
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:292
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:294
+#: adhocracy4/reports/static/reports/react_reports.jsx:20
+#: adhocracy4/comments/static/comments/Comment.jsx:32
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:294
 #: adhocracy4/reports/static/reports/react_reports.jsx:20
 msgid ""
 "You want to report this content? Your message will be sent to the "
@@ -81,15 +93,21 @@ msgstr ""
 "удален, если он не соответствует нашим правилам обсуждения (сетевой этикет)."
 
 #: adhocracy4/comments/static/comments/Comment.jsx:96
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:269
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:271
+#: adhocracy4/comments/static/comments/Comment.jsx:96
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:271
 msgid "Moderator"
 msgstr "Модератор"
 
 #: adhocracy4/comments/static/comments/Comment.jsx:105
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:264
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:266
+#: adhocracy4/comments/static/comments/Comment.jsx:105
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:266
 msgid "Latest edit on"
 msgstr "Последнее изменение на"
 
+#: adhocracy4/comments/static/comments/Comment.jsx:110
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:260
 #: adhocracy4/comments/static/comments/Comment.jsx:110
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:260
 msgid "Deleted by creator on"
@@ -97,9 +115,13 @@ msgstr ""
 
 #: adhocracy4/comments/static/comments/Comment.jsx:112
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:262
+#: adhocracy4/comments/static/comments/Comment.jsx:112
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:262
 msgid "Deleted by moderator on"
 msgstr ""
 
+#: adhocracy4/comments/static/comments/Comment.jsx:151
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:241
 #: adhocracy4/comments/static/comments/Comment.jsx:151
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:241
 msgid "Do you really want to delete this comment?"
@@ -113,6 +135,10 @@ msgstr "Вы действительно хотите удалить этот к�
 #: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:73
 #: adhocracy4/polls/assets/EditPollQuestion.jsx:152
 #: adhocracy4/polls/assets/EditPollQuestion.jsx:157
+#: adhocracy4/comments/static/comments/Comment.jsx:152
+#: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:7
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:243
+#: adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx:22
 #: apps/documents/assets/ChapterNavItem.jsx:56
 #: apps/documents/assets/ChapterNavItem.jsx:61
 #: apps/documents/assets/ParagraphForm.jsx:133
@@ -125,14 +151,21 @@ msgstr "Удалить"
 #: adhocracy4/comments_async/static/modals/modal.jsx:58
 #: adhocracy4/comments_async/static/modals/moderate_modal.jsx:54
 #: adhocracy4/static/Modal.jsx:59
+#: adhocracy4/comments/static/comments/Comment.jsx:153
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:244
+#: adhocracy4/comments_async/static/modals/modal.jsx:58
+#: adhocracy4/comments_async/static/modals/moderate_modal.jsx:54
 msgid "Abort"
 msgstr "Отменить"
 
 #: adhocracy4/comments/static/comments/CommentBox.jsx:165
 #: adhocracy4/comments/static/comments/CommentEditForm.jsx:34
+#: adhocracy4/comments/static/comments/CommentBox.jsx:165
+#: adhocracy4/comments/static/comments/CommentEditForm.jsx:34
 msgid "Your comment here"
 msgstr "Ваш комментарий здесь"
 
+#: adhocracy4/comments/static/comments/CommentBox.jsx:168
 #: adhocracy4/comments/static/comments/CommentBox.jsx:168
 msgid "comment"
 msgid_plural "comments"
@@ -144,9 +177,15 @@ msgstr[3] "Комментарии"
 #: adhocracy4/comments/static/comments/CommentEditForm.jsx:35
 #: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:76
 #: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:48
+#: adhocracy4/comments/static/comments/CommentEditForm.jsx:35
+#: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:76
+#: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:48
 msgid "save changes"
 msgstr "Сохранить изменения"
 
+#: adhocracy4/comments/static/comments/CommentEditForm.jsx:36
+#: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:79
+#: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:51
 #: adhocracy4/comments/static/comments/CommentEditForm.jsx:36
 #: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:79
 #: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:51
@@ -156,9 +195,14 @@ msgstr "Отмена"
 #: adhocracy4/comments/static/comments/CommentForm.jsx:37
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:107
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:108
+#: adhocracy4/comments/static/comments/CommentForm.jsx:37
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:107
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:108
 msgid "post"
 msgstr "Сообщение"
 
+#: adhocracy4/comments/static/comments/CommentForm.jsx:38
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:117
 #: adhocracy4/comments/static/comments/CommentForm.jsx:38
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:117
 msgid "Please login to comment"
@@ -166,9 +210,13 @@ msgstr "Пожалуйста, выполните вход, чтобы остав
 
 #: adhocracy4/comments/static/comments/CommentForm.jsx:39
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:129
+#: adhocracy4/comments/static/comments/CommentForm.jsx:39
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:129
 msgid "The currently active phase doesn't allow to comment."
 msgstr "Текущая активная фаза не позволяет комментировать."
 
+#: adhocracy4/comments/static/comments/CommentForm.jsx:40
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:123
 #: adhocracy4/comments/static/comments/CommentForm.jsx:40
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:123
 msgid "Only invited users can actively participate."
@@ -176,41 +224,52 @@ msgstr "Только приглашенные пользователи могу�
 
 #: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:6
 #: adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx:18
+#: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:6
+#: adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx:18
 msgid "Edit"
 msgstr "Редактировать"
 
+#: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:8
 #: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:8
 msgid "Report"
 msgstr "Отчет"
 
 #: adhocracy4/comments_async/static/comments_async/category_list.jsx:6
+#: adhocracy4/comments_async/static/comments_async/category_list.jsx:6
 msgid "Choose categories for your comment"
 msgstr "Выберите категории для вашего комментария"
 
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:19
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:19
 msgid "Entry successfully created"
 msgstr "Запись успешно создана"
 
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:20
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:20
 msgid "Read more..."
 msgstr "Читать больше..."
 
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:21
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:21
 msgid "Read less"
 msgstr "Читать меньше"
 
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:22
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:22
 msgid "Share"
 msgstr "Поделиться"
 
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:23
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:23
 msgid " Report"
 msgstr "Отчет"
 
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:33
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:33
 msgid "hide comments"
 msgstr "скрыть комментарии"
 
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:36
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:36
 #, javascript-format
 msgid "1 comment"
@@ -221,34 +280,47 @@ msgstr[2] "%sкомментариев"
 msgstr[3] "%sкомментариев"
 
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:39
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:39
 msgctxt "verb"
 msgid "Comment"
 msgstr "Комментировать"
 
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:299
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:264
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:264
+msgid "Blocked by moderator on"
+msgstr ""
+
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:301
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:301
 msgid "Share link"
 msgstr "Поделиться ссылкой"
 
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:339
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:341
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:341
 msgid "Categories: "
 msgstr "Категории:"
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:15
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:15
 msgid "Newest"
 msgstr "Новейшие"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:16
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:16
 msgid "Most up votes"
 msgstr "Наибольшее количество голосов за"
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:17
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:17
 msgid "Most down votes"
 msgstr "Наибольшее количество голосов против"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:18
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:18
 msgid "Most answers"
 msgstr "Большинство ответов"
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:19
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:19
 msgid "Last discussed"
 msgstr "Последнее обсуждение"
@@ -256,10 +328,18 @@ msgstr "Последнее обсуждение"
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:51
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:310
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:545
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:29
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:51
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:310
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:545
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_box.jsx:57
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:32
 msgid "all"
 msgstr "Все"
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:503
+#: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:72
+#: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:44
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:96
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:503
 #: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:72
 #: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:44
@@ -269,21 +349,27 @@ msgstr "Написать вклад"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:519
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:523
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:519
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:523
 msgid "Search contributions"
 msgstr "Поиск вкладов"
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:521
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:521
 msgid "Clear search"
 msgstr "Очистить поиск"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:537
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:537
 msgid "display: "
 msgstr "Показать:"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:566
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:566
 msgid "sorted by: "
 msgstr "Отсортировано по:"
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:587
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:587
 msgid "entry"
 msgid_plural "entries"
@@ -293,6 +379,7 @@ msgstr[2] "Записей"
 msgstr[3] "Записи"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:591
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:591
 msgid "entry found for "
 msgid_plural "entries found for "
 msgstr[0] "найденная запись для"
@@ -301,42 +388,52 @@ msgstr[2] "найденные записи для"
 msgstr[3] "найденные записи для"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:595
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:595
 msgid "Filters"
 msgstr "Фильтры"
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:595
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:595
 msgid "Show filters"
 msgstr "Показать фильтры"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:598
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:598
 msgid "Hide Filters"
 msgstr "Скрыть фильтры"
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:598
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:598
 msgid "Hide filters"
 msgstr "Скрыть фильтры"
 
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:104
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:104
 #: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_form.jsx:78
 msgid " characters"
 msgstr "Символы"
 
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:108
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:108
 msgid "Comment"
 msgstr "Комментировать"
 
+#: adhocracy4/comments_async/static/modals/moderate_modal.jsx:31
 #: adhocracy4/comments_async/static/modals/moderate_modal.jsx:31
 msgid "Recommend comment"
 msgstr "Рекомендовать комментарий"
 
 #: adhocracy4/comments_async/static/modals/moderate_modal.jsx:35
+#: adhocracy4/comments_async/static/modals/moderate_modal.jsx:35
 msgid "Is recommended"
 msgstr "Рекомендовано"
 
 #: adhocracy4/comments_async/static/modals/moderate_modal.jsx:53
+#: adhocracy4/comments_async/static/modals/moderate_modal.jsx:53
 msgid "Submit"
 msgstr "Подать"
 
+#: adhocracy4/comments_async/static/modals/report_modal.jsx:62
 #: adhocracy4/comments_async/static/modals/report_modal.jsx:62
 msgid ""
 "Thanks for the feedback. It will be checked by the moderators as soon as "
@@ -345,34 +442,44 @@ msgstr "Спасибо за ответ. Он будет проверен мод�
 
 #: adhocracy4/comments_async/static/modals/report_modal.jsx:71
 #: adhocracy4/reports/static/reports/ReportModal.jsx:61
+#: adhocracy4/comments_async/static/modals/report_modal.jsx:71
+#: adhocracy4/reports/static/reports/ReportModal.jsx:61
 msgid "Your message"
 msgstr "Ваше сообщение"
 
+#: adhocracy4/comments_async/static/modals/report_modal.jsx:84
+#: adhocracy4/reports/static/reports/ReportModal.jsx:62
 #: adhocracy4/comments_async/static/modals/report_modal.jsx:84
 #: adhocracy4/reports/static/reports/ReportModal.jsx:62
 msgid "Send Report"
 msgstr "Отправить отчет"
 
 #: adhocracy4/comments_async/static/modals/url_modal.jsx:23
+#: adhocracy4/comments_async/static/modals/url_modal.jsx:23
 msgid "Copy"
 msgstr "Копировать"
 
+#: adhocracy4/comments_async/static/modals/url_modal.jsx:24
 #: adhocracy4/comments_async/static/modals/url_modal.jsx:24
 msgid "Copied"
 msgstr "Скопировано"
 
 #: adhocracy4/follows/static/follows/FollowButton.jsx:27
+#: adhocracy4/follows/static/follows/FollowButton.jsx:27
 msgid "You will no longer be updated via email."
 msgstr "Вы больше не будете получать обновления по электронной почте."
 
+#: adhocracy4/follows/static/follows/FollowButton.jsx:29
 #: adhocracy4/follows/static/follows/FollowButton.jsx:29
 msgid "You will be updated via email."
 msgstr "Вы будете получать обновления по электронной почте."
 
 #: adhocracy4/follows/static/follows/FollowButton.jsx:63
+#: adhocracy4/follows/static/follows/FollowButton.jsx:63
 msgid "Follow"
 msgstr "Подписаться"
 
+#: adhocracy4/follows/static/follows/FollowButton.jsx:64
 #: adhocracy4/follows/static/follows/FollowButton.jsx:64
 msgid "Following"
 msgstr "Подписанный"
@@ -563,6 +670,7 @@ msgid "Your choice"
 msgstr "Ваш выбор"
 
 #: adhocracy4/reports/static/reports/ReportModal.jsx:60
+#: adhocracy4/reports/static/reports/ReportModal.jsx:60
 msgid "Thank you! We are taking care of it."
 msgstr "Спасибо! Мы позаботимся об этом."
 
@@ -675,7 +783,6 @@ msgid "Click to view list of marked questions screen"
 msgstr ""
 
 #: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_box.jsx:27
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_box.jsx:57
 msgid "select affiliation"
 msgstr "Выберите принадлежность"
 
@@ -699,15 +806,15 @@ msgstr "Фильтры"
 msgid "Click to view filters"
 msgstr ""
 
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:30
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:29
 msgid "Click to only display marked questions"
 msgstr ""
 
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:31
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:30
 msgid "Click to only display questions which are not hidden"
 msgstr ""
 
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:32
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:31
 msgid "Click to order list by likes"
 msgstr ""
 

--- a/locale-source/locale/tr/LC_MESSAGES/django.po
+++ b/locale-source/locale/tr/LC_MESSAGES/django.po
@@ -11,7 +11,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: adhocracy-plus\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-19 10:30+0200\n"
+"POT-Creation-Date: 2021-11-19 13:49+0100\n"
 "PO-Revision-Date: 2020-11-12 13:23+0000\n"
 "Last-Translator: Katharina Lindenlaub, 2020\n"
 "Language-Team: Turkish (https://www.transifex.com/liqd/teams/109316/tr/)\n"
@@ -20,6 +20,357 @@ msgstr ""
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
+
+#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
+#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
+msgid ""
+"In this section, you can create\n"
+"categories. If you create any, each contribution has to be assigned\n"
+"to one of them. This way, content can be classified."
+msgstr ""
+
+#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:21
+#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:21
+msgid "Add category"
+msgstr "Kategori ekleyin"
+
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard.html:4
+#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:51
+msgid "Dashboard"
+msgstr ""
+
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:5
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:5
+#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:24
+msgid "Project Settings"
+msgstr "Proje Ayarları"
+
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:15
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:33
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:15
+#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:33
+#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:49
+#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:103
+msgid "Missing fields for publication"
+msgstr ""
+
+#: adhocracy4/dashboard/templates/a4dashboard/base_form_module.html:18
+#: adhocracy4/dashboard/templates/a4dashboard/base_form_project.html:18
+#: adhocracy4/dashboard/templates/a4dashboard/base_form_module.html:18
+#: adhocracy4/dashboard/templates/a4dashboard/base_form_project.html:18
+#: apps/activities/templates/a4_candy_activities/activities_dashboard.html:17
+#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_form.html:30
+#: apps/budgeting/templates/a4_candy_budgeting/proposal_moderate_form.html:39
+#: apps/debate/templates/a4_candy_debate/includes/subject_form.html:11
+#: apps/ideas/templates/a4_candy_ideas/idea_moderate_form.html:44
+#: apps/ideas/templates/a4_candy_ideas/includes/idea_form.html:24
+#: apps/interactiveevents/templates/a4_candy_interactive_events/extrafields_dashboard_form.html:19
+#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_form.html:28
+#: apps/mapideas/templates/a4_candy_mapideas/mapidea_moderate_form.html:43
+#: apps/moderatorremark/templates/a4_candy_moderatorremark/includes/popover_remark.html:27
+#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_form.html:15
+#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_form.html:22
+#: adhocracy-plus/templates/a4dashboard/base_form_module.html:23
+#: adhocracy-plus/templates/a4dashboard/base_form_project.html:23
+msgid "Save"
+msgstr "Kaydet"
+
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:9
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:9
+#: adhocracy-plus/templates/a4dashboard/blueprint_list.html:4
+#: adhocracy-plus/templates/a4dashboard/project_list.html:13
+msgid "New Project"
+msgstr "Yeni Proje"
+
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:17
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:17
+msgid "Phase"
+msgstr ""
+
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:23
+#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:23
+#: adhocracy-plus/templates/a4dashboard/includes/blueprint_list_tile.html:15
+msgid "Select"
+msgstr ""
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/form_field.html:6
+#: adhocracy4/dashboard/templates/a4dashboard/includes/form_field.html:6
+msgid "Missing field for publication"
+msgstr ""
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:39
+#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:39
+#: adhocracy-plus/templates/a4dashboard/includes/preview.html:7
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:34
+msgid "Preview"
+msgstr "Önizleme"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:9
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:41
+#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:9
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:41
+#: apps/contrib/templates/a4_candy_contrib/includes/map_filter_and_sort.html:8
+#: apps/contrib/templates/a4_candy_contrib/includes/map_filter_and_sort.html:14
+#: apps/debate/templates/a4_candy_debate/includes/subject_dashboard_list_item.html:14
+#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_list_item.html:15
+#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_dashboard_list_item.html:14
+#: adhocracy-plus/templates/a4dashboard/includes/preview.html:9
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:36
+msgid "View"
+msgstr ""
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:16
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:16
+#, python-format
+msgid "%(value)s from %(max)s"
+msgstr ""
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:17
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:17
+msgid "required fields for publication"
+msgstr ""
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:27
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:27
+#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:12
+#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:46
+msgid "Publish"
+msgstr "Yayınla"
+
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:31
+#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:31
+#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:19
+msgid "Unpublish"
+msgstr "Yayından Kaldır"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:7
+msgid "Create project based on"
+msgstr ""
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:23
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:23
+#: adhocracy-plus/templates/a4dashboard/project_create_form.html:41
+msgid ""
+"After saving the draft project you can further customize and edit your "
+"project and eventually publish it."
+msgstr ""
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:25
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:25
+#: adhocracy-plus/templates/a4dashboard/project_create_form.html:46
+msgid "Create draft"
+msgstr ""
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:27
+#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:27
+#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_form.html:29
+#: apps/budgeting/templates/a4_candy_budgeting/proposal_confirm_delete.html:15
+#: apps/budgeting/templates/a4_candy_budgeting/proposal_moderate_form.html:38
+#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:40
+#: apps/debate/templates/a4_candy_debate/includes/subject_form.html:10
+#: apps/debate/templates/a4_candy_debate/subject_confirm_delete.html:15
+#: apps/embed/templates/a4_candy_embed/embed.html:47
+#: apps/ideas/templates/a4_candy_ideas/idea_confirm_delete.html:16
+#: apps/ideas/templates/a4_candy_ideas/idea_moderate_form.html:43
+#: apps/ideas/templates/a4_candy_ideas/includes/idea_form.html:23
+#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_form.html:27
+#: apps/mapideas/templates/a4_candy_mapideas/mapidea_confirm_delete.html:15
+#: apps/mapideas/templates/a4_candy_mapideas/mapidea_moderate_form.html:42
+#: apps/newsletters/templates/a4_candy_newsletters/restricted_newsletter_dashboard_form.html:29
+#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_form.html:14
+#: apps/offlineevents/templates/a4_candy_offlineevents/offlineevent_confirm_delete.html:15
+#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_form.html:21
+#: apps/topicprio/templates/a4_candy_topicprio/topic_confirm_delete.html:15
+#: adhocracy-plus/templates/a4dashboard/project_create_form.html:45
+msgid "Cancel"
+msgstr "İptal"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:7
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:4
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:7
+#: apps/projects/templates/a4_candy_projects/project_list.html:4
+#: adhocracy-plus/templates/a4dashboard/base_project_list.html:16
+#: adhocracy-plus/templates/a4dashboard/project_list.html:4
+#: adhocracy-plus/templates/a4dashboard/project_list.html:9
+msgid "Projects"
+msgstr "Projeler"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:24
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:24
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:17
+msgid "Finished"
+msgstr "Tamamlandı"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:27
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:27
+#: adhocracy4/projects/enums.py:14
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:20
+msgid "semipublic"
+msgstr ""
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:30
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:30
+#: adhocracy4/projects/enums.py:15
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:23
+msgid "private"
+msgstr "Özel"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:48
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:48
+#: apps/contrib/templates/a4_candy_contrib/item_detail.html:103
+#: apps/debate/templates/a4_candy_debate/includes/subject_dashboard_list_item.html:19
+#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_list_item.html:20
+#: apps/projects/templates/a4_candy_projects/project_detail.html:112
+#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_dashboard_list_item.html:19
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:42
+msgid "Edit"
+msgstr ""
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:57
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:57
+#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:65
+msgid "Duplicate"
+msgstr "Çoğalt"
+
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:65
+#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:65
+#: apps/projects/templates/a4_candy_projects/project_list.html:18
+#: adhocracy-plus/templates/a4dashboard/project_list.html:27
+msgid "We could not find any projects."
+msgstr ""
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:5
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:23
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:35
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:47
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:59
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:5
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:23
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:35
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:47
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:59
+msgid "Export"
+msgstr ""
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:7
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:7
+msgid ""
+"You can export the results of your participation project as an excel file."
+msgstr ""
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:19
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:19
+msgid "here you can export all ideas"
+msgstr ""
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:31
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:31
+msgid "here you can export all subjects"
+msgstr ""
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:43
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:43
+msgid "here you can export all answers"
+msgstr ""
+
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:55
+#: adhocracy4/exports/templates/a4exports/export_dashboard.html:55
+msgid "here you can export all comments"
+msgstr ""
+
+#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html:15
+#: adhocracy4/dashboard/filter.py:11
+#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html:15
+#: apps/debate/filters.py:12 apps/ideas/views.py:28 apps/topicprio/views.py:21
+#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:4
+#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:10
+#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:11
+msgid "Search"
+msgstr "Ara"
+
+#: adhocracy4/forms/templates/a4forms/includes/form_field.html:5
+#: adhocracy4/forms/templates/a4forms/includes/form_field.html:5
+#: apps/contrib/templates/a4_candy_contrib/includes/form_field.html:5
+#: adhocracy-plus/templates/account/signup.html:27
+#: adhocracy-plus/templates/account/signup.html:36
+#: adhocracy-plus/templates/socialaccount/signup.html:31
+msgid "This field is required"
+msgstr ""
+
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:14
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:15
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:18
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:19
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:14
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:15
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:18
+#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:19
+msgid "Remove category"
+msgstr "Kategori sil"
+
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:8
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:8
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:10
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:11
+msgid "Remove the picture"
+msgstr "Resmi sil"
+
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:12
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:12
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:16
+#: adhocracy-plus/templates/a4images/image_upload_widget.html:17
+msgid "Upload a picture"
+msgstr "Resim yükle"
+
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:19
+#: adhocracy4/images/templates/a4images/image_upload_widget.html:19
+msgid ""
+"\n"
+"            Your image will be uploaded/removed once you save your changes\n"
+"            at the end of this page.\n"
+"            "
+msgstr ""
+
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
+msgid ""
+"In this section, you can create\n"
+"labels. If you create any, each contribution can be assigned\n"
+"to one or more of them. This way, content can be classified."
+msgstr ""
+
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:21
+#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:21
+msgid "Add label"
+msgstr ""
+
+#: adhocracy4/polls/templates/a4polls/poll_404.html:8
+#: adhocracy4/polls/templates/a4polls/poll_404.html:8
+msgid ""
+"Participation is not possible at the moment. The poll has not been set up "
+"yet."
+msgstr ""
+
+#: adhocracy4/polls/templates/a4polls/poll_404.html:15
+#: adhocracy4/polls/templates/a4polls/poll_404.html:15
+msgid "Setup the poll by adding questions and answers in the dashboard."
+msgstr ""
+
+#: adhocracy4/polls/templates/a4polls/poll_dashboard.html:5
+#: adhocracy4/polls/templates/a4polls/poll_dashboard.html:5
+msgid "Edit poll"
+msgstr ""
 
 #: adhocracy4/categories/dashboard.py:13
 #: apps/exports/mixins.py:19
@@ -46,18 +397,7 @@ msgstr ""
 msgid "Category icon"
 msgstr ""
 
-#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:3
-msgid ""
-"In this section, you can create\n"
-"categories. If you create any, each contribution has to be assigned\n"
-"to one of them. This way, content can be classified."
-msgstr ""
-
-#: adhocracy4/categories/templates/a4categories/includes/module_categories_form.html:21
-msgid "Add category"
-msgstr "Kategori ekleyin"
-
-#: adhocracy4/comments/models.py:53
+#: adhocracy4/comments/models.py:54
 #: adhocracy4/polls/exports.py:41
 #: apps/budgeting/exports.py:75 apps/debate/exports.py:64
 #: apps/documents/exports.py:40 apps/ideas/exports.py:70
@@ -66,7 +406,7 @@ msgctxt "noun"
 msgid "Comment"
 msgstr ""
 
-#: adhocracy4/comments/models.py:54
+#: adhocracy4/comments/models.py:55
 #: adhocracy4/exports/mixins/comments.py:46
 #: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_list_item.html:16
 #: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_list_item.html:17
@@ -79,17 +419,17 @@ msgstr ""
 msgid "Comments"
 msgstr ""
 
-#: adhocracy4/comments/serializers.py:52
-#: adhocracy4/comments/serializers.py:151
+#: adhocracy4/comments/serializers.py:73
+#: adhocracy4/comments/serializers.py:175
 msgid "Please choose a category"
 msgstr ""
 
-#: adhocracy4/comments/serializers.py:61
-#: adhocracy4/comments_async/serializers.py:79
+#: adhocracy4/comments/serializers.py:82
+#: adhocracy4/comments_async/serializers.py:84
 msgid "unknown user"
 msgstr ""
 
-#: adhocracy4/comments_async/serializers.py:58
+#: adhocracy4/comments_async/serializers.py:63
 msgid "Please choose one or more categories."
 msgstr ""
 
@@ -154,15 +494,6 @@ msgstr ""
 #: adhocracy4/dashboard/dashboard.py:65
 msgid "Edit areasettings"
 msgstr ""
-
-#: adhocracy4/dashboard/filter.py:11
-#: adhocracy4/filters/templates/a4filters/widgets/free_text_filter.html:15
-#: apps/debate/filters.py:12 apps/ideas/views.py:28 apps/topicprio/views.py:21
-#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:4
-#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:10
-#: adhocracy-plus/templates/a4filters/widgets/free_text_filter.html:11
-msgid "Search"
-msgstr "Ara"
 
 #: adhocracy4/dashboard/filter.py:15
 #: apps/budgeting/views.py:26
@@ -235,189 +566,6 @@ msgstr ""
 
 #: adhocracy4/dashboard/mixins.py:207
 msgid "Project successfully duplicated."
-msgstr ""
-
-#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard.html:4
-#: adhocracy-plus/templates/a4dashboard/base_dashboard.html:51
-msgid "Dashboard"
-msgstr ""
-
-#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:5
-#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:24
-msgid "Project Settings"
-msgstr "Proje Ayarları"
-
-#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:15
-#: adhocracy4/dashboard/templates/a4dashboard/base_dashboard_project.html:33
-#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:49
-#: adhocracy-plus/templates/a4dashboard/base_dashboard_project.html:103
-msgid "Missing fields for publication"
-msgstr ""
-
-#: adhocracy4/dashboard/templates/a4dashboard/base_form_module.html:18
-#: adhocracy4/dashboard/templates/a4dashboard/base_form_project.html:18
-#: apps/activities/templates/a4_candy_activities/activities_dashboard.html:17
-#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_form.html:30
-#: apps/budgeting/templates/a4_candy_budgeting/proposal_moderate_form.html:39
-#: apps/debate/templates/a4_candy_debate/includes/subject_form.html:11
-#: apps/ideas/templates/a4_candy_ideas/idea_moderate_form.html:44
-#: apps/ideas/templates/a4_candy_ideas/includes/idea_form.html:24
-#: apps/interactiveevents/templates/a4_candy_interactive_events/extrafields_dashboard_form.html:19
-#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_form.html:28
-#: apps/mapideas/templates/a4_candy_mapideas/mapidea_moderate_form.html:43
-#: apps/moderatorremark/templates/a4_candy_moderatorremark/includes/popover_remark.html:27
-#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_form.html:15
-#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_form.html:22
-#: adhocracy-plus/templates/a4dashboard/base_form_module.html:23
-#: adhocracy-plus/templates/a4dashboard/base_form_project.html:23
-msgid "Save"
-msgstr "Kaydet"
-
-#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:4
-#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:7
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:9
-#: adhocracy-plus/templates/a4dashboard/blueprint_list.html:4
-#: adhocracy-plus/templates/a4dashboard/project_list.html:13
-msgid "New Project"
-msgstr "Yeni Proje"
-
-#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:17
-msgid "Phase"
-msgstr ""
-
-#: adhocracy4/dashboard/templates/a4dashboard/blueprint_list.html:23
-#: adhocracy-plus/templates/a4dashboard/includes/blueprint_list_tile.html:15
-msgid "Select"
-msgstr ""
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/form_field.html:6
-msgid "Missing field for publication"
-msgstr ""
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:7
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:39
-#: adhocracy-plus/templates/a4dashboard/includes/preview.html:7
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:34
-msgid "Preview"
-msgstr "Önizleme"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/preview.html:9
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:41
-#: apps/contrib/templates/a4_candy_contrib/includes/map_filter_and_sort.html:8
-#: apps/contrib/templates/a4_candy_contrib/includes/map_filter_and_sort.html:14
-#: apps/debate/templates/a4_candy_debate/includes/subject_dashboard_list_item.html:14
-#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_list_item.html:15
-#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_dashboard_list_item.html:14
-#: adhocracy-plus/templates/a4dashboard/includes/preview.html:9
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:36
-msgid "View"
-msgstr ""
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:16
-#, python-format
-msgid "%(value)s from %(max)s"
-msgstr ""
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:17
-msgid "required fields for publication"
-msgstr ""
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:27
-#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:12
-#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:46
-msgid "Publish"
-msgstr "Yayınla"
-
-#: adhocracy4/dashboard/templates/a4dashboard/includes/progress.html:31
-#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:19
-msgid "Unpublish"
-msgstr "Yayından Kaldır"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:4
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:7
-msgid "Create project based on"
-msgstr ""
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:23
-#: adhocracy-plus/templates/a4dashboard/project_create_form.html:41
-msgid ""
-"After saving the draft project you can further customize and edit your "
-"project and eventually publish it."
-msgstr ""
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:25
-#: adhocracy-plus/templates/a4dashboard/project_create_form.html:46
-msgid "Create draft"
-msgstr ""
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_create_form.html:27
-#: apps/budgeting/templates/a4_candy_budgeting/includes/proposal_form.html:29
-#: apps/budgeting/templates/a4_candy_budgeting/proposal_confirm_delete.html:15
-#: apps/budgeting/templates/a4_candy_budgeting/proposal_moderate_form.html:38
-#: apps/dashboard/templates/a4_candy_dashboard/includes/progress.html:40
-#: apps/debate/templates/a4_candy_debate/includes/subject_form.html:10
-#: apps/debate/templates/a4_candy_debate/subject_confirm_delete.html:15
-#: apps/embed/templates/a4_candy_embed/embed.html:47
-#: apps/ideas/templates/a4_candy_ideas/idea_confirm_delete.html:16
-#: apps/ideas/templates/a4_candy_ideas/idea_moderate_form.html:43
-#: apps/ideas/templates/a4_candy_ideas/includes/idea_form.html:23
-#: apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_form.html:27
-#: apps/mapideas/templates/a4_candy_mapideas/mapidea_confirm_delete.html:15
-#: apps/mapideas/templates/a4_candy_mapideas/mapidea_moderate_form.html:42
-#: apps/newsletters/templates/a4_candy_newsletters/restricted_newsletter_dashboard_form.html:29
-#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_form.html:14
-#: apps/offlineevents/templates/a4_candy_offlineevents/offlineevent_confirm_delete.html:15
-#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_form.html:21
-#: apps/topicprio/templates/a4_candy_topicprio/topic_confirm_delete.html:15
-#: adhocracy-plus/templates/a4dashboard/project_create_form.html:45
-msgid "Cancel"
-msgstr "İptal"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:4
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:7
-#: apps/projects/templates/a4_candy_projects/project_list.html:4
-#: adhocracy-plus/templates/a4dashboard/base_project_list.html:16
-#: adhocracy-plus/templates/a4dashboard/project_list.html:4
-#: adhocracy-plus/templates/a4dashboard/project_list.html:9
-msgid "Projects"
-msgstr "Projeler"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:24
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:17
-msgid "Finished"
-msgstr "Tamamlandı"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:27
-#: adhocracy4/projects/enums.py:14
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:20
-msgid "semipublic"
-msgstr ""
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:30
-#: adhocracy4/projects/enums.py:15
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:23
-msgid "private"
-msgstr "Özel"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:48
-#: apps/contrib/templates/a4_candy_contrib/item_detail.html:103
-#: apps/debate/templates/a4_candy_debate/includes/subject_dashboard_list_item.html:19
-#: apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_list_item.html:20
-#: apps/projects/templates/a4_candy_projects/project_detail.html:112
-#: apps/topicprio/templates/a4_candy_topicprio/includes/topic_dashboard_list_item.html:19
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:42
-msgid "Edit"
-msgstr ""
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:57
-#: adhocracy-plus/templates/a4dashboard/includes/project_list_item.html:65
-msgid "Duplicate"
-msgstr "Çoğalt"
-
-#: adhocracy4/dashboard/templates/a4dashboard/project_list.html:65
-#: apps/projects/templates/a4_candy_projects/project_list.html:18
-#: adhocracy-plus/templates/a4dashboard/project_list.html:27
-msgid "We could not find any projects."
 msgstr ""
 
 #: adhocracy4/dashboard/views.py:69
@@ -532,54 +680,10 @@ msgstr ""
 msgid "Negative ratings"
 msgstr ""
 
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:5
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:23
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:35
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:47
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:59
-msgid "Export"
-msgstr ""
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:7
-msgid ""
-"You can export the results of your participation project as an excel file."
-msgstr ""
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:19
-msgid "here you can export all ideas"
-msgstr ""
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:31
-msgid "here you can export all subjects"
-msgstr ""
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:43
-msgid "here you can export all answers"
-msgstr ""
-
-#: adhocracy4/exports/templates/a4exports/export_dashboard.html:55
-msgid "here you can export all comments"
-msgstr ""
-
 #: adhocracy4/forms/fields.py:18
 #, python-format
 msgid "Time of %(date_label)s"
 msgstr ""
-
-#: adhocracy4/forms/templates/a4forms/includes/form_field.html:5
-#: apps/contrib/templates/a4_candy_contrib/includes/form_field.html:5
-#: adhocracy-plus/templates/account/signup.html:27
-#: adhocracy-plus/templates/account/signup.html:36
-#: adhocracy-plus/templates/socialaccount/signup.html:31
-msgid "This field is required"
-msgstr ""
-
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:14
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:15
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:18
-#: adhocracy4/forms/templates/a4forms/includes/inline_form.html:19
-msgid "Remove category"
-msgstr "Kategori sil"
 
 #: adhocracy4/images/fields.py:71
 #, python-brace-format
@@ -597,26 +701,6 @@ msgstr ""
 #: adhocracy4/images/fields.py:94
 #, python-brace-format
 msgid "Copyright shown in the {image_name}."
-msgstr ""
-
-#: adhocracy4/images/templates/a4images/image_upload_widget.html:8
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:10
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:11
-msgid "Remove the picture"
-msgstr "Resmi sil"
-
-#: adhocracy4/images/templates/a4images/image_upload_widget.html:12
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:16
-#: adhocracy-plus/templates/a4images/image_upload_widget.html:17
-msgid "Upload a picture"
-msgstr "Resim yükle"
-
-#: adhocracy4/images/templates/a4images/image_upload_widget.html:19
-msgid ""
-"\n"
-"            Your image will be uploaded/removed once you save your changes\n"
-"            at the end of this page.\n"
-"            "
 msgstr ""
 
 #: adhocracy4/images/validators.py:21
@@ -653,17 +737,6 @@ msgstr ""
 
 #: adhocracy4/labels/forms.py:17
 msgid "Label"
-msgstr ""
-
-#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:3
-msgid ""
-"In this section, you can create\n"
-"labels. If you create any, each contribution can be assigned\n"
-"to one or more of them. This way, content can be classified."
-msgstr ""
-
-#: adhocracy4/labels/templates/a4labels/includes/module_labels_form.html:21
-msgid "Add label"
 msgstr ""
 
 #: adhocracy4/maps/admin.py:14
@@ -877,20 +950,6 @@ msgstr ""
 
 #: adhocracy4/polls/phases.py:21
 msgid "polls"
-msgstr ""
-
-#: adhocracy4/polls/templates/a4polls/poll_404.html:8
-msgid ""
-"Participation is not possible at the moment. The poll has not been set up "
-"yet."
-msgstr ""
-
-#: adhocracy4/polls/templates/a4polls/poll_404.html:15
-msgid "Setup the poll by adding questions and answers in the dashboard."
-msgstr ""
-
-#: adhocracy4/polls/templates/a4polls/poll_dashboard.html:5
-msgid "Edit poll"
 msgstr ""
 
 #: adhocracy4/polls/validators.py:15

--- a/locale-source/locale/tr/LC_MESSAGES/djangojs.po
+++ b/locale-source/locale/tr/LC_MESSAGES/djangojs.po
@@ -8,7 +8,7 @@ msgid ""
 msgstr ""
 "Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-10-19 10:30+0200\n"
+"POT-Creation-Date: 2021-11-19 13:49+0100\n"
 "PO-Revision-Date: 2020-11-12 13:23+0000\n"
 "Language-Team: Turkish (https://www.transifex.com/liqd/teams/109316/tr/)\n"
 "Language: tr\n"
@@ -18,21 +18,26 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n > 1);\n"
 
 #: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:12
+#: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:12
 msgid "Insert Collapsible Item"
 msgstr ""
 
+#: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:14
 #: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:14
 msgid "Title"
 msgstr ""
 
 #: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:15
+#: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:15
 msgid "Body text"
 msgstr ""
 
 #: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:37
+#: adhocracy4/ckeditor/static/ckeditor_collapsible/plugin.js:37
 msgid "Collapsible element"
 msgstr ""
 
+#: adhocracy4/comments/static/comments/Comment.jsx:23
 #: adhocracy4/comments/static/comments/Comment.jsx:23
 #, javascript-format
 msgid "hide one reply"
@@ -41,6 +46,7 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: adhocracy4/comments/static/comments/Comment.jsx:25
+#: adhocracy4/comments/static/comments/Comment.jsx:25
 #, javascript-format
 msgid "view one reply"
 msgid_plural "view %s replies"
@@ -48,16 +54,22 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: adhocracy4/comments/static/comments/Comment.jsx:30
+#: adhocracy4/comments/static/comments/Comment.jsx:30
 msgid "Answer"
 msgstr ""
 
 #: adhocracy4/comments/static/comments/Comment.jsx:31
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:418
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:420
+#: adhocracy4/comments/static/comments/Comment.jsx:31
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:420
 msgid "Your reply here"
 msgstr ""
 
 #: adhocracy4/comments/static/comments/Comment.jsx:32
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:292
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:294
+#: adhocracy4/reports/static/reports/react_reports.jsx:20
+#: adhocracy4/comments/static/comments/Comment.jsx:32
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:294
 #: adhocracy4/reports/static/reports/react_reports.jsx:20
 msgid ""
 "You want to report this content? Your message will be sent to the "
@@ -66,15 +78,21 @@ msgid ""
 msgstr ""
 
 #: adhocracy4/comments/static/comments/Comment.jsx:96
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:269
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:271
+#: adhocracy4/comments/static/comments/Comment.jsx:96
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:271
 msgid "Moderator"
 msgstr ""
 
 #: adhocracy4/comments/static/comments/Comment.jsx:105
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:264
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:266
+#: adhocracy4/comments/static/comments/Comment.jsx:105
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:266
 msgid "Latest edit on"
 msgstr ""
 
+#: adhocracy4/comments/static/comments/Comment.jsx:110
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:260
 #: adhocracy4/comments/static/comments/Comment.jsx:110
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:260
 msgid "Deleted by creator on"
@@ -82,9 +100,13 @@ msgstr ""
 
 #: adhocracy4/comments/static/comments/Comment.jsx:112
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:262
+#: adhocracy4/comments/static/comments/Comment.jsx:112
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:262
 msgid "Deleted by moderator on"
 msgstr ""
 
+#: adhocracy4/comments/static/comments/Comment.jsx:151
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:241
 #: adhocracy4/comments/static/comments/Comment.jsx:151
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:241
 msgid "Do you really want to delete this comment?"
@@ -98,6 +120,10 @@ msgstr ""
 #: adhocracy4/polls/assets/EditPollOpenQuestion.jsx:73
 #: adhocracy4/polls/assets/EditPollQuestion.jsx:152
 #: adhocracy4/polls/assets/EditPollQuestion.jsx:157
+#: adhocracy4/comments/static/comments/Comment.jsx:152
+#: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:7
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:243
+#: adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx:22
 #: apps/documents/assets/ChapterNavItem.jsx:56
 #: apps/documents/assets/ChapterNavItem.jsx:61
 #: apps/documents/assets/ParagraphForm.jsx:133
@@ -110,14 +136,21 @@ msgstr ""
 #: adhocracy4/comments_async/static/modals/modal.jsx:58
 #: adhocracy4/comments_async/static/modals/moderate_modal.jsx:54
 #: adhocracy4/static/Modal.jsx:59
+#: adhocracy4/comments/static/comments/Comment.jsx:153
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:244
+#: adhocracy4/comments_async/static/modals/modal.jsx:58
+#: adhocracy4/comments_async/static/modals/moderate_modal.jsx:54
 msgid "Abort"
 msgstr ""
 
 #: adhocracy4/comments/static/comments/CommentBox.jsx:165
 #: adhocracy4/comments/static/comments/CommentEditForm.jsx:34
+#: adhocracy4/comments/static/comments/CommentBox.jsx:165
+#: adhocracy4/comments/static/comments/CommentEditForm.jsx:34
 msgid "Your comment here"
 msgstr ""
 
+#: adhocracy4/comments/static/comments/CommentBox.jsx:168
 #: adhocracy4/comments/static/comments/CommentBox.jsx:168
 msgid "comment"
 msgid_plural "comments"
@@ -127,9 +160,15 @@ msgstr[1] ""
 #: adhocracy4/comments/static/comments/CommentEditForm.jsx:35
 #: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:76
 #: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:48
+#: adhocracy4/comments/static/comments/CommentEditForm.jsx:35
+#: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:76
+#: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:48
 msgid "save changes"
 msgstr ""
 
+#: adhocracy4/comments/static/comments/CommentEditForm.jsx:36
+#: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:79
+#: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:51
 #: adhocracy4/comments/static/comments/CommentEditForm.jsx:36
 #: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:79
 #: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:51
@@ -139,9 +178,14 @@ msgstr ""
 #: adhocracy4/comments/static/comments/CommentForm.jsx:37
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:107
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:108
+#: adhocracy4/comments/static/comments/CommentForm.jsx:37
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:107
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:108
 msgid "post"
 msgstr ""
 
+#: adhocracy4/comments/static/comments/CommentForm.jsx:38
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:117
 #: adhocracy4/comments/static/comments/CommentForm.jsx:38
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:117
 msgid "Please login to comment"
@@ -149,9 +193,13 @@ msgstr ""
 
 #: adhocracy4/comments/static/comments/CommentForm.jsx:39
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:129
+#: adhocracy4/comments/static/comments/CommentForm.jsx:39
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:129
 msgid "The currently active phase doesn't allow to comment."
 msgstr ""
 
+#: adhocracy4/comments/static/comments/CommentForm.jsx:40
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:123
 #: adhocracy4/comments/static/comments/CommentForm.jsx:40
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:123
 msgid "Only invited users can actively participate."
@@ -159,41 +207,52 @@ msgstr ""
 
 #: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:6
 #: adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx:18
+#: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:6
+#: adhocracy4/comments_async/static/comments_async/comment_manage_dropdown.jsx:18
 msgid "Edit"
 msgstr ""
 
+#: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:8
 #: adhocracy4/comments/static/comments/CommentManageDropdown.jsx:8
 msgid "Report"
 msgstr ""
 
 #: adhocracy4/comments_async/static/comments_async/category_list.jsx:6
+#: adhocracy4/comments_async/static/comments_async/category_list.jsx:6
 msgid "Choose categories for your comment"
 msgstr ""
 
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:19
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:19
 msgid "Entry successfully created"
 msgstr ""
 
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:20
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:20
 msgid "Read more..."
 msgstr ""
 
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:21
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:21
 msgid "Read less"
 msgstr ""
 
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:22
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:22
 msgid "Share"
 msgstr ""
 
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:23
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:23
 msgid " Report"
 msgstr ""
 
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:33
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:33
 msgid "hide comments"
 msgstr ""
 
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:36
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:36
 #, javascript-format
 msgid "1 comment"
@@ -202,34 +261,47 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: adhocracy4/comments_async/static/comments_async/comment.jsx:39
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:39
 msgctxt "verb"
 msgid "Comment"
 msgstr ""
 
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:299
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:264
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:264
+msgid "Blocked by moderator on"
+msgstr ""
+
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:301
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:301
 msgid "Share link"
 msgstr ""
 
-#: adhocracy4/comments_async/static/comments_async/comment.jsx:339
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:341
+#: adhocracy4/comments_async/static/comments_async/comment.jsx:341
 msgid "Categories: "
 msgstr ""
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:15
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:15
 msgid "Newest"
 msgstr ""
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:16
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:16
 msgid "Most up votes"
 msgstr ""
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:17
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:17
 msgid "Most down votes"
 msgstr ""
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:18
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:18
 msgid "Most answers"
 msgstr ""
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:19
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:19
 msgid "Last discussed"
 msgstr ""
@@ -237,10 +309,18 @@ msgstr ""
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:51
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:310
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:545
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:29
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:51
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:310
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:545
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_box.jsx:57
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:32
 msgid "all"
 msgstr ""
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:503
+#: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:72
+#: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:44
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:96
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:503
 #: adhocracy4/comments_async/static/comments_async/comment_category_edit_form.jsx:72
 #: adhocracy4/comments_async/static/comments_async/comment_edit_form.jsx:44
@@ -250,21 +330,27 @@ msgstr ""
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:519
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:523
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:519
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:523
 msgid "Search contributions"
 msgstr ""
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:521
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:521
 msgid "Clear search"
 msgstr ""
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:537
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:537
 msgid "display: "
 msgstr ""
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:566
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:566
 msgid "sorted by: "
 msgstr ""
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:587
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:587
 msgid "entry"
 msgid_plural "entries"
@@ -272,48 +358,59 @@ msgstr[0] ""
 msgstr[1] ""
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:591
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:591
 msgid "entry found for "
 msgid_plural "entries found for "
 msgstr[0] ""
 msgstr[1] ""
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:595
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:595
 msgid "Filters"
 msgstr ""
 
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:595
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:595
 msgid "Show filters"
 msgstr ""
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:598
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:598
 msgid "Hide Filters"
 msgstr ""
 
 #: adhocracy4/comments_async/static/comments_async/comment_box.jsx:598
+#: adhocracy4/comments_async/static/comments_async/comment_box.jsx:598
 msgid "Hide filters"
 msgstr ""
 
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:104
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:104
 #: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_form.jsx:78
 msgid " characters"
 msgstr ""
 
 #: adhocracy4/comments_async/static/comments_async/comment_form.jsx:108
+#: adhocracy4/comments_async/static/comments_async/comment_form.jsx:108
 msgid "Comment"
 msgstr ""
 
+#: adhocracy4/comments_async/static/modals/moderate_modal.jsx:31
 #: adhocracy4/comments_async/static/modals/moderate_modal.jsx:31
 msgid "Recommend comment"
 msgstr ""
 
 #: adhocracy4/comments_async/static/modals/moderate_modal.jsx:35
+#: adhocracy4/comments_async/static/modals/moderate_modal.jsx:35
 msgid "Is recommended"
 msgstr ""
 
 #: adhocracy4/comments_async/static/modals/moderate_modal.jsx:53
+#: adhocracy4/comments_async/static/modals/moderate_modal.jsx:53
 msgid "Submit"
 msgstr ""
 
+#: adhocracy4/comments_async/static/modals/report_modal.jsx:62
 #: adhocracy4/comments_async/static/modals/report_modal.jsx:62
 msgid ""
 "Thanks for the feedback. It will be checked by the moderators as soon as "
@@ -322,34 +419,44 @@ msgstr ""
 
 #: adhocracy4/comments_async/static/modals/report_modal.jsx:71
 #: adhocracy4/reports/static/reports/ReportModal.jsx:61
+#: adhocracy4/comments_async/static/modals/report_modal.jsx:71
+#: adhocracy4/reports/static/reports/ReportModal.jsx:61
 msgid "Your message"
 msgstr ""
 
+#: adhocracy4/comments_async/static/modals/report_modal.jsx:84
+#: adhocracy4/reports/static/reports/ReportModal.jsx:62
 #: adhocracy4/comments_async/static/modals/report_modal.jsx:84
 #: adhocracy4/reports/static/reports/ReportModal.jsx:62
 msgid "Send Report"
 msgstr ""
 
 #: adhocracy4/comments_async/static/modals/url_modal.jsx:23
+#: adhocracy4/comments_async/static/modals/url_modal.jsx:23
 msgid "Copy"
 msgstr ""
 
+#: adhocracy4/comments_async/static/modals/url_modal.jsx:24
 #: adhocracy4/comments_async/static/modals/url_modal.jsx:24
 msgid "Copied"
 msgstr ""
 
 #: adhocracy4/follows/static/follows/FollowButton.jsx:27
+#: adhocracy4/follows/static/follows/FollowButton.jsx:27
 msgid "You will no longer be updated via email."
 msgstr ""
 
+#: adhocracy4/follows/static/follows/FollowButton.jsx:29
 #: adhocracy4/follows/static/follows/FollowButton.jsx:29
 msgid "You will be updated via email."
 msgstr ""
 
 #: adhocracy4/follows/static/follows/FollowButton.jsx:63
+#: adhocracy4/follows/static/follows/FollowButton.jsx:63
 msgid "Follow"
 msgstr ""
 
+#: adhocracy4/follows/static/follows/FollowButton.jsx:64
 #: adhocracy4/follows/static/follows/FollowButton.jsx:64
 msgid "Following"
 msgstr ""
@@ -536,6 +643,7 @@ msgid "Your choice"
 msgstr ""
 
 #: adhocracy4/reports/static/reports/ReportModal.jsx:60
+#: adhocracy4/reports/static/reports/ReportModal.jsx:60
 msgid "Thank you! We are taking care of it."
 msgstr ""
 
@@ -646,7 +754,6 @@ msgid "Click to view list of marked questions screen"
 msgstr ""
 
 #: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_box.jsx:27
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_box.jsx:57
 msgid "select affiliation"
 msgstr ""
 
@@ -668,15 +775,15 @@ msgstr ""
 msgid "Click to view filters"
 msgstr ""
 
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:30
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:29
 msgid "Click to only display marked questions"
 msgstr ""
 
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:31
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:30
 msgid "Click to only display questions which are not hidden"
 msgstr ""
 
-#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:32
+#: apps/interactiveevents/assets/js/a4_candy_interactive_events/livequestion_filters.jsx:31
 msgid "Click to order list by likes"
 msgstr ""
 


### PR DESCRIPTION
Fixes #1585

The application (**2nd commit**) of the changed `make po` script (**1st commit**) led to some duplicate lines in the po files. 

These were left untouched because they are likely a result of the changed makemessages command, and would thus be generated anytime make po is executed in future.
