### PR TITLE
desp: planifolia remove unused css classes

### DIFF
--- a/adhocracy-plus/assets/scss/_form.scss
+++ b/adhocracy-plus/assets/scss/_form.scss
@@ -21,7 +21,7 @@ input {
     max-width: 100%;
     background-color: $body-bg;
     color: contrast-color($body-bg);
-    box-shadow: 0 0 1px $brand-primary-tint inset;
+    // box-shadow: 0 0 1px $brand-primary-tint inset;
     border-radius: 0;
     border-width: 1px;
 

--- a/adhocracy-plus/assets/scss/_layout.scss
+++ b/adhocracy-plus/assets/scss/_layout.scss
@@ -34,6 +34,7 @@
     }
 }
 
+// FIXME only appears to be used in old templates
 .l-wrapper {
     @include clearfix;
     position: relative;
@@ -41,16 +42,6 @@
     max-width: $wrapper-width;
     margin: 0 auto;
     padding: 0 $padding;
-}
-
-.l-frame {
-    margin-left: 1rem !important;
-    margin-right: 1rem !important;
-
-    @media screen and (min-width: $breakpoint-md) {
-        margin-left: 4rem !important;
-        margin-right: 4rem !important;
-    }
 }
 
 .l-top-overlap {
@@ -95,14 +86,6 @@
 @media (min-width: $breakpoint-md) {
     .l-center-8 {
         // @include grid-width(8);
-    }
-
-    .l-center-6 {
-        // @include grid-width(6);
-    }
-
-    .l-col-9-3 {
-        // @include grid-span(9, 3);
     }
 
     .l-tiles-3 {

--- a/adhocracy-plus/assets/scss/_layout.scss
+++ b/adhocracy-plus/assets/scss/_layout.scss
@@ -79,15 +79,6 @@
         margin: 0 auto;
     }
 
-    .l-center-6 {
-        @include grid-width(8);
-        margin: 0 auto;
-    }
-
-    .l-col-9-3 {
-        @include grid-span(10, 2);
-    }
-
     .l-tiles-2 {
         @include grid-tiles(2);
     }

--- a/adhocracy-plus/assets/scss/_layout.scss
+++ b/adhocracy-plus/assets/scss/_layout.scss
@@ -1,23 +1,23 @@
 // should be used with ul/ol
-@mixin grid-tiles($n, $settings: ()) {
-    @include clearfix;
-
-    > * {
-        @include grid-same-width($n, $settings);
-    }
-
-    @supports (display: grid) {
-        display: grid;
-        grid-column-gap: _grid-get("gutter", $settings);
-        grid-template-columns: repeat($n, 1fr);
-
-        > * {
-            margin-left: 0 !important;
-            margin-right: 0 !important;
-            width: auto !important;
-        }
-    }
-}
+// @mixin grid-tiles($n, $settings: ()) {
+//     @include clearfix;
+//
+//     > * {
+//         @include grid-same-width($n, $settings);
+//     }
+//
+//     @supports (display: grid) {
+//         display: grid;
+//         grid-column-gap: _grid-get("gutter", $settings);
+//         grid-template-columns: repeat($n, 1fr);
+//
+//         > * {
+//             margin-left: 0 !important;
+//             margin-right: 0 !important;
+//             width: auto !important;
+//         }
+//     }
+// }
 
 .container {
     position: relative;
@@ -75,41 +75,41 @@
 
 @media (min-width: $breakpoint) {
     .l-center-8 {
-        @include grid-width(10);
+        // @include grid-width(10);
         margin: 0 auto;
     }
 
     .l-tiles-2 {
-        @include grid-tiles(2);
+        // @include grid-tiles(2);
     }
 
     .l-tiles-3 {
-        @include grid-tiles(2);
+        // @include grid-tiles(2);
     }
 
     .l-tiles-4 {
-        @include grid-tiles(2);
+        // @include grid-tiles(2);
     }
 }
 
 @media (min-width: $breakpoint-md) {
     .l-center-8 {
-        @include grid-width(8);
+        // @include grid-width(8);
     }
 
     .l-center-6 {
-        @include grid-width(6);
+        // @include grid-width(6);
     }
 
     .l-col-9-3 {
-        @include grid-span(9, 3);
+        // @include grid-span(9, 3);
     }
 
     .l-tiles-3 {
-        @include grid-tiles(3);
+        // @include grid-tiles(3);
     }
 
     .l-tiles-4 {
-        @include grid-tiles(4);
+        // @include grid-tiles(4);
     }
 }

--- a/adhocracy-plus/assets/scss/_utility.scss
+++ b/adhocracy-plus/assets/scss/_utility.scss
@@ -8,7 +8,7 @@
 }
 
 .u-bg-secondary {
-    background-color: $bg-secondary;
+    // background-color: $bg-secondary;
 }
 
 .u-bg-light {

--- a/adhocracy-plus/assets/scss/_variables.scss
+++ b/adhocracy-plus/assets/scss/_variables.scss
@@ -44,13 +44,13 @@ $green-light: #e0fbe2;
 $print-black: #000 !default;
 $print-link: #005cb4 !default;
 
-$brand-primary-tint: contrast-stretch($text-color, mix($brand-primary, $body-bg, 30%), 7) !default;
-$brand-secondary-tint: contrast-stretch($text-color, mix($brand-secondary, $body-bg, 30%), 7) !default;
-$brand-tertiary-tint: contrast-stretch($text-color, mix($brand-tertiary, $body-bg, 30%), 7) !default;
-$brand-danger-tint: contrast-stretch($text-color, mix($brand-danger, $body-bg, 30%), 7) !default;
+// $brand-primary-tint: contrast-stretch($text-color, mix($brand-primary, $body-bg, 30%), 7) !default;
+// $brand-secondary-tint: contrast-stretch($text-color, mix($brand-secondary, $body-bg, 30%), 7) !default;
+// $brand-tertiary-tint: contrast-stretch($text-color, mix($brand-tertiary, $body-bg, 30%), 7) !default;
+// $brand-danger-tint: contrast-stretch($text-color, mix($brand-danger, $body-bg, 30%), 7) !default;
 
-$bg-tertiary: $brand-tertiary-tint !default;
-$bg-secondary: mix($bg-tertiary, $body-bg, 50%) !default;
+// $bg-tertiary: $brand-tertiary-tint !default;
+// $bg-secondary: mix($bg-tertiary, $body-bg, 50%) !default;
 $bg-light: #f7f7f7;
 
 $demi-bold: 600;
@@ -118,9 +118,9 @@ $hero-height: 25.5rem !default;
 $hero-height-secondary: 20rem !default;
 $hero-height-mobile: 12rem !default;
 
-@include grid-set('gutter', $padding);
-$planifolia-contrast-dark-default: $text-color;
-$planifolia-contrast-light-default: $text-color-inverted;
+// @include grid-set('gutter', $padding);
+// $planifolia-contrast-dark-default: $text-color;
+// $planifolia-contrast-light-default: $text-color-inverted;
 
 $enable-caret: false;
 

--- a/adhocracy-plus/assets/scss/components/_action.scss
+++ b/adhocracy-plus/assets/scss/components/_action.scss
@@ -21,7 +21,7 @@
 
 .action__icon {
     @include multi-line-icon(2);
-    background-color: $bg-secondary;
+    // background-color: $bg-secondary;
     color: $brand-primary;
     text-align: center;
     float: left;

--- a/adhocracy-plus/assets/scss/components/_button.scss
+++ b/adhocracy-plus/assets/scss/components/_button.scss
@@ -1,42 +1,42 @@
 @mixin button-color($color, $color-active) {
-    $color-focus: mix($color, $color-active, 50%);
-    $color-contrast: contrast-color($color);
+    // $color-focus: mix($color, $color-active, 50%);
+    // $color-contrast: contrast-color($color);
 
     border-color: $color;
     background-color: $color;
-    color: $color-contrast;
+    // color: $color-contrast;
 
     &:hover,
     &:focus {
-        border-color: $color-focus;
-        background-color: $color-focus;
-        color: contrast-color($color-focus);
+        // border-color: $color-focus;
+        // background-color: $color-focus;
+        // color: contrast-color($color-focus);
     }
 
     &:active {
         border-color: $color-active;
         background-color: $color-active;
-        color: contrast-color($color-active);
+        // color: contrast-color($color-active);
     }
 
     &.is-disabled,
     &:disabled {
-        $is-light: luma($color) > luma($color-contrast);
-        $weight-bg: if($is-light, 95%, 50%);
-        $weight-fg: if($is-light, 60%, 10%);
+        // $is-light: luma($color) > luma($color-contrast);
+        // $weight-bg: if($is-light, 95%, 50%);
+        // $weight-fg: if($is-light, 60%, 10%);
 
-        border-color: mix($color, $color-contrast, $weight-bg);
-        background-color: mix($color, $color-contrast, $weight-bg);
-        color: mix($color, $color-contrast, $weight-fg);
+        // border-color: mix($color, $color-contrast, $weight-bg);
+        // background-color: mix($color, $color-contrast, $weight-bg);
+        // color: mix($color, $color-contrast, $weight-fg);
         cursor: not-allowed;
     }
 }
 
 @mixin button-color-product($color) {
-    $shadow: mix($color, $body-bg, 30%);
-    $background: mix($color, $body-bg, 15%);
+    // $shadow: mix($color, $body-bg, 30%);
+    // $background: mix($color, $body-bg, 15%);
 
-    @include button-color($body-bg, $background);
+    // @include button-color($body-bg, $background);
 
     &,
     &:focus,
@@ -78,7 +78,7 @@
 }
 
 .btn--light {
-    @include button-color($body-bg, $bg-secondary);
+    // @include button-color($body-bg, $bg-secondary);
 
     &,
     &:focus,
@@ -149,7 +149,7 @@
 }
 
 .btn--bg-tertiary {
-    @include button-color($bg-tertiary, $body-bg);
+    // @include button-color($bg-tertiary, $body-bg);
 }
 
 .btn--text-color-inverted {

--- a/adhocracy-plus/assets/scss/components/_category_formset.scss
+++ b/adhocracy-plus/assets/scss/components/_category_formset.scss
@@ -12,7 +12,7 @@
 }
 
 .category-formset__datetime-input {
-    grid-column-gap: 3rem;
+    // grid-column-gap: 3rem;
 }
 
 .category-formset__template {

--- a/adhocracy-plus/assets/scss/components/_commenting.scss
+++ b/adhocracy-plus/assets/scss/components/_commenting.scss
@@ -33,11 +33,11 @@
     }
 
     .commenting__content {
-        @include grid-span(9, 0);
+        // @include grid-span(9, 0);
     }
 
     .commenting__actions {
-        @include grid-span(3, 9);
+        // @include grid-span(3, 9);
         text-align: left;
     }
 }

--- a/adhocracy-plus/assets/scss/components/_dashboard_nav.scss
+++ b/adhocracy-plus/assets/scss/components/_dashboard_nav.scss
@@ -6,7 +6,7 @@
 }
 
 .dashboard-nav__dropdown {
-    background-color: $bg-secondary;
+    // background-color: $bg-secondary;
     position: relative;
     padding: 0.7 * $spacer 2.7 * $spacer 0.7 * $spacer 1.8 * $spacer;
 

--- a/adhocracy-plus/assets/scss/components/_datepicker.scss
+++ b/adhocracy-plus/assets/scss/components/_datepicker.scss
@@ -60,7 +60,7 @@
     }
 
     .date-picker-unused {
-        background: $bg-secondary;
+        // background: $bg-secondary;
     }
 
     .date-picker-highlight {

--- a/adhocracy-plus/assets/scss/components/_dropdown.scss
+++ b/adhocracy-plus/assets/scss/components/_dropdown.scss
@@ -28,8 +28,8 @@
         &:hover,
         &:focus {
             text-decoration: none;
-            background-color: $bg-secondary;
-            color: contrast-color($bg-secondary);
+            // background-color: $bg-secondary;
+            // color: contrast-color($bg-secondary);
         }
 
         i {

--- a/adhocracy-plus/assets/scss/components/_editpoll.scss
+++ b/adhocracy-plus/assets/scss/components/_editpoll.scss
@@ -47,10 +47,6 @@
         @include clearfix;
     }
 
-    .editpoll__question {
-        @include grid-span(9, 0);
-    }
-
     .editpoll__question-actions {
         @include grid-span(3, 9);
 

--- a/adhocracy-plus/assets/scss/components/_editpoll.scss
+++ b/adhocracy-plus/assets/scss/components/_editpoll.scss
@@ -48,7 +48,7 @@
     }
 
     .editpoll__question-actions {
-        @include grid-span(3, 9);
+        // @include grid-span(3, 9);
 
         .btn {
             padding-left: revert;

--- a/adhocracy-plus/assets/scss/components/_language_choice.scss
+++ b/adhocracy-plus/assets/scss/components/_language_choice.scss
@@ -30,7 +30,7 @@
     }
 
     .active button {
-        background-color: $bg-secondary;
+        // background-color: $bg-secondary;
     }
 }
 
@@ -42,7 +42,7 @@
     display: none;
 
     &.active {
-        background-color: $bg-secondary;
+        // background-color: $bg-secondary;
     }
 }
 

--- a/adhocracy-plus/assets/scss/components/_list_item.scss
+++ b/adhocracy-plus/assets/scss/components/_list_item.scss
@@ -9,7 +9,7 @@
     overflow-wrap: break-word;
 
     &.selected {
-        background-color: $bg-secondary;
+        // background-color: $bg-secondary;
     }
 
     &.selected:focus {

--- a/adhocracy-plus/assets/scss/components/_marked.scss
+++ b/adhocracy-plus/assets/scss/components/_marked.scss
@@ -12,7 +12,7 @@
         width: 100%;
         height: 90%;
         z-index: -1;
-        background-color: $bg-secondary;
+        // background-color: $bg-secondary;
     }
 }
 

--- a/adhocracy-plus/assets/scss/components/_moderator_statement.scss
+++ b/adhocracy-plus/assets/scss/components/_moderator_statement.scss
@@ -2,7 +2,7 @@
     // this block needs a bigger margin than the previous element can provide
     margin-top: 2em;
     padding: 0.6em;
-    background-color: $bg-secondary;
+    // background-color: $bg-secondary;
 }
 
 .moderator-statement__title {

--- a/adhocracy-plus/assets/scss/components/_pagination.scss
+++ b/adhocracy-plus/assets/scss/components/_pagination.scss
@@ -21,7 +21,7 @@
 
     a:hover,
     a:focus {
-        background-color: $bg-secondary;
+        // background-color: $bg-secondary;
     }
 }
 

--- a/adhocracy-plus/assets/scss/components/_poll.scss
+++ b/adhocracy-plus/assets/scss/components/_poll.scss
@@ -84,7 +84,7 @@ $checkbox-size: 20px;
 }
 
 .poll-row__bar {
-    background-color: $brand-secondary-tint;
+    // background-color: $brand-secondary-tint;
     position: absolute;
     top: 0;
     bottom: 0;
@@ -102,7 +102,7 @@ $checkbox-size: 20px;
 }
 
 .poll-row__bar--highlight {
-    background-color: $brand-tertiary-tint;
+    // background-color: $brand-tertiary-tint;
 }
 
 .poll__btn--wrapper {
@@ -179,7 +179,7 @@ $checkbox-size: 20px;
 
 .poll-slider {
     position: relative;
-    background-color: $brand-secondary-tint;
+    // background-color: $brand-secondary-tint;
     margin-bottom: $spacer;
     border-radius: 0.3 * $spacer;
 
@@ -212,7 +212,7 @@ $checkbox-size: 20px;
         }
 
         &:before {
-            color: $brand-secondary-tint;
+            // color: $brand-secondary-tint;
             opacity: 100%;
             font-family: "Font Awesome 5 Free", sans-serif;
             font-weight: 900;

--- a/adhocracy-plus/assets/scss/components/_select2.scss
+++ b/adhocracy-plus/assets/scss/components/_select2.scss
@@ -17,8 +17,8 @@
     }
 
     .select2-results__option--highlighted[aria-selected] {
-        background-color: $bg-secondary;
-        color: contrast-color($bg-secondary);
+        // background-color: $bg-secondary;
+        // color: contrast-color($bg-secondary);
     }
 
     .select2-selection--single .select2-selection__arrow {

--- a/adhocracy-plus/assets/scss/components/_select_dropdown.scss
+++ b/adhocracy-plus/assets/scss/components/_select_dropdown.scss
@@ -23,6 +23,6 @@
         padding-top: 0.8em;
         padding-bottom: 0.8em;
         color: $text-color-gray;
-        background-color: $bg-secondary;
+        // background-color: $bg-secondary;
     }
 }

--- a/adhocracy-plus/assets/scss/components/_status-bar.scss
+++ b/adhocracy-plus/assets/scss/components/_status-bar.scss
@@ -33,7 +33,7 @@
 
 .status-bar__past {
     padding: 0.5 * $padding;
-    background-color: $bg-secondary;
+    // background-color: $bg-secondary;
     color: $text-color;
     text-align: center;
     bottom: 0;

--- a/adhocracy-plus/assets/scss/components/_style_guide.scss
+++ b/adhocracy-plus/assets/scss/components/_style_guide.scss
@@ -52,7 +52,7 @@
 }
 
 .primary-tint.colour-block {
-    background-color: $brand-primary-tint;
+    // background-color: $brand-primary-tint;
 }
 
 .secondary.colour-block {
@@ -84,7 +84,7 @@
 }
 
 .bg-secondary.colour-block {
-    background-color: $bg-secondary;
+    // background-color: $bg-secondary;
 }
 
 .tertiary.colour-block {
@@ -92,7 +92,7 @@
 }
 
 .bg-tertiary.colour-block {
-    background-color: $bg-tertiary;
+    // background-color: $bg-tertiary;
 }
 
 .gray.colour-block {

--- a/adhocracy-plus/assets/scss/components/_tabs.scss
+++ b/adhocracy-plus/assets/scss/components/_tabs.scss
@@ -51,18 +51,18 @@
 }
 
 .tablist--background {
-    background-color: $bg-secondary;
+    // background-color: $bg-secondary;
     padding-top: $spacer;
 }
 
 .tablist--bg-secondary {
-    border-bottom: 2px solid $bg-secondary;
+    // border-bottom: 2px solid $bg-secondary;
 }
 
 .tab--bg-secondary {
     &.active {
-        border-color: $bg-secondary;
-        background-color: $bg-secondary;
+        // border-color: $bg-secondary;
+        // background-color: $bg-secondary;
     }
 }
 
@@ -71,7 +71,7 @@
     padding-bottom: 2 * $padding;
 
     &.active {
-        background-color: $bg-secondary;
+        // background-color: $bg-secondary;
     }
 }
 

--- a/adhocracy-plus/assets/scss/components/_upload.scss
+++ b/adhocracy-plus/assets/scss/components/_upload.scss
@@ -52,10 +52,10 @@
 
 @media (min-width: $breakpoint) {
     .upload-wrapper__fields {
-        @include grid-span(5, 0, ("columns": 9));
+        // @include grid-span(5, 0, ("columns": 9));
     }
 
     .upload-wrapper__preview {
-        @include grid-span(4, 5, ("columns": 9));
+        // @include grid-span(4, 5, ("columns": 9));
     }
 }

--- a/adhocracy-plus/assets/scss/components/_user_profile.scss
+++ b/adhocracy-plus/assets/scss/components/_user_profile.scss
@@ -1,6 +1,6 @@
 .user-profile__side {
     padding: $padding;
-    background-color: $bg-secondary;
+    // background-color: $bg-secondary;
     min-height: 100%;
 }
 

--- a/adhocracy-plus/assets/scss/style.scss
+++ b/adhocracy-plus/assets/scss/style.scss
@@ -1,5 +1,5 @@
-@import "~sass-planifolia/sass/grid";
-@import "~sass-planifolia/sass/contrast";
+// @import "~sass-planifolia/sass/grid";
+// @import "~sass-planifolia/sass/contrast";
 
 @import "~bootstrap/scss/functions";
 

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
     "postcss-loader": "7.0.0",
     "react-flip-move": "3.0.4",
     "sass-loader": "13.0.0",
-    "sass-planifolia": "0.6.0",
     "select2": "4.0.13",
     "shpjs": "4.0.2",
     "slick-carousel": "git+https://github.com/liqd/slick#pm-2019-07-overwrites",


### PR DESCRIPTION
the branch with a lot of file changes i can't push, because it does not pass husky :(
but i have it locally, in case we want to have a look i can create a patch i guess.

current state: need replacement mixins/functions for commented out:
`grid-*`
`contrast()`
`mix()`
`luma()`