### PR TITLE
modules/tiles: using combination of overflow-wrap hyphens and smaller…

### DIFF
--- a/adhocracy-plus/assets/scss/components/_participation-tile.scss
+++ b/adhocracy-plus/assets/scss/components/_participation-tile.scss
@@ -39,6 +39,12 @@
 
 .participation-tile__content {
     padding: 1.5 * $padding;
+    overflow-wrap: normal;
+    hyphens: auto;
+
+    @media (min-width: $breakpoint-lg) {
+        hyphens: none;
+    }
 }
 
 .participation-tile__horizontal,
@@ -91,6 +97,14 @@
 
 .participation-tile__title {
     margin-top: 0;
+
+    @media screen and (min-width: $breakpoint-md) {
+        font-size: $font-size-md;
+    }
+
+    @media screen and (min-width: $breakpoint-lg) {
+        font-size: $font-size-lg;
+    }
 }
 
 .participation-tile__btn {


### PR DESCRIPTION
… fontsize to asssure proper word wrapping.

This is one approach to close #1780 

As spoken with @mcastro-lqd the font-size used is too big. So i am using `<h4>` rather than modifying `<h3>` (there is a systematic behind it with screen sizes etc.)

Then to word-wrap the css property `overflow-wrap` is used to not allow wrapping on weird places.

Additionally using css property `hyphens`, but only for smaller screen sizes, otherwise it will wrap quite earlier and look weird. And also languages are not very well supported in browsers other than english/german (see caniuse.com)