### PR TITLE
wagtail: remove deprecated hallo.js richt text

### DIFF
--- a/adhocracy-plus/config/settings/base.py
+++ b/adhocracy-plus/config/settings/base.py
@@ -427,12 +427,6 @@ BLEACH_LIST = {
 WAGTAIL_SITE_NAME = 'adhocracy+'
 WAGTAILIMAGES_IMAGE_MODEL = 'a4_candy_cms_images.CustomImage'
 
-WAGTAILADMIN_RICH_TEXT_EDITORS = {
-    'default': {
-        'WIDGET': 'wagtail.admin.rich_text.HalloRichTextArea'
-    }
-}
-
 # adhocracy4
 
 A4_ORGANISATIONS_MODEL = 'a4_candy_organisations.Organisation'


### PR DESCRIPTION
replace the hallojs richt-text editor with the newer in-built draftail editor

partly fixes #1844 