### PR TITLE
Revert "webpack: don't export entry points as library"

### DIFF
--- a/webpack.common.js
+++ b/webpack.common.js
@@ -112,6 +112,12 @@ module.exports = {
     }
   },
   output: {
+    // exposes exports of entry points
+    library: {
+      name: '[name]',
+      // return value of entry point will be assigned this.
+      type: 'this'
+    },
     // creates a folder to store all assets
     path: path.resolve('./adhocracy-plus/static/'),
     // location they can be accessed, can also be a url


### PR DESCRIPTION
This reverts commit 5745d5c59204d19dbbeb090c71fde5d50a5f8651.