### PR TITLE
accordion: fix overlapping project and module ideas

### DIFF
--- a/adhocracy-plus/assets/js/init_dashboard_accordion.js
+++ b/adhocracy-plus/assets/js/init_dashboard_accordion.js
@@ -24,25 +24,27 @@ function initDashboardAccordion () {
 
   const manageCookie = (currentElement) => {
     const currentId = parseInt(currentElement.id.split('--')[1])
+    const isProject = currentElement.id.startsWith('dashboard-nav__project--')
     const cookie = Cookies.get(COOKIE_NAME)
     const currentExpanded = !currentElement.classList.contains('collapsed')
+    let current = [[], []]
     let currentList = []
 
     if (cookie) {
-      currentList = JSON.parse(cookie)
+      current = JSON.parse(cookie)
     }
-
+    currentList = current[isProject ? 0 : 1]
     if (!currentExpanded && !currentList.includes(currentId)) {
       currentList.push(currentId)
-      setCookie(JSON.stringify(currentList))
+      setCookie(JSON.stringify(current))
     } else if (currentExpanded && currentList.includes(currentId)) {
       currentList.splice(currentList.indexOf(currentId), 1)
-      setCookie(JSON.stringify(currentList))
+      setCookie(JSON.stringify(current))
     }
   }
 
   if (Cookies.get(COOKIE_NAME) === undefined) {
-    setCookie('[]')
+    setCookie('[[], []]')
   }
 
   manageObservers()

--- a/adhocracy-plus/templates/a4dashboard/base_dashboard_project.html
+++ b/adhocracy-plus/templates/a4dashboard/base_dashboard_project.html
@@ -24,11 +24,11 @@
         <nav class="col-md-3 js-selector-update-dashboard" aria-label="{% trans 'Project Settings' %}">
             <div class="dashboard-nav">
                 <div
-                    class="dashboard-nav__dropdown{% if project.id in closed_accordions %} collapsed{% endif %}"
+                    class="dashboard-nav__dropdown{% if project.id in closed_accordions.0 %} collapsed{% endif %}"
                     id="dashboard-nav__project--{{ project.id }}"
                     data-bs-toggle="collapse"
                     href="#dashboardCollapseProj"
-                    aria-expanded="{% if project.id in closed_accordions %}false{% else %}true{% endif %}"
+                    aria-expanded="{% if project.id in closed_accordions.0 %}false{% else %}true{% endif %}"
                     aria-controls="#dashboardCollapseProj"
                     data-bs-target="#dashboardCollapseProj"
                 >
@@ -40,7 +40,7 @@
                     {{ project.name }}
                     <i class="fa fa-chevron-up" aria-hidden="true"></i>
                 </div>
-                <ul class="dashboard-nav__pages collapse{% if not project.id in closed_accordions %} show{% endif %}" id="dashboardCollapseProj" aria-hidden="false">
+                <ul class="dashboard-nav__pages collapse{% if not project.id in closed_accordions.0 %} show{% endif %}" id="dashboardCollapseProj" aria-hidden="false">
                     {% for item in dashboard_menu.project %}
                         <li class="dashboard-nav__page">
                             <a href="{{ item.url }}"
@@ -77,11 +77,11 @@
                 {% endif %}
                 <div class="dashboard-nav">
                     <div
-                        class="dashboard-nav__dropdown{% if module_menu.module.pk in closed_accordions %} collapsed{% endif %}"
+                        class="dashboard-nav__dropdown{% if module_menu.module.pk in closed_accordions.1 %} collapsed{% endif %}"
                         id="dashboard-nav__module--{{ module_menu.module.pk }}"
                         data-bs-toggle="collapse"
                         href="#dashboardCollapse_{{ forloop.counter }}"
-                        aria-expanded="{% if module_menu.module.pk in closed_accordions %}false{% else %}true{% endif %}"
+                        aria-expanded="{% if module_menu.module.pk in closed_accordions.1 %}false{% else %}true{% endif %}"
                         aria-controls="#dashboardCollapse_{{ forloop.counter }}"
                         data-bs-target="#dashboardCollapse_{{ forloop.counter }}"
                     >
@@ -94,7 +94,7 @@
                       <i class="fa fa-chevron-up {% if module_menu.module.is_draft %}dashboard-nav-i-spacer{% endif %}" aria-hidden="true"></i>
                     </div>
 
-                    <ul class="dashboard-nav__pages collapse{% if not module_menu.module.pk in closed_accordions %} show{% endif %}" id="dashboardCollapse_{{ forloop.counter }}" aria-hidden="false">
+                    <ul class="dashboard-nav__pages collapse{% if not module_menu.module.pk in closed_accordions.1 %} show{% endif %}" id="dashboardCollapse_{{ forloop.counter }}" aria-hidden="false">
                         {% for item in module_menu.menu %}
                             <li class="dashboard-nav__page">
                               <a href="{{ item.url }}"

--- a/apps/dashboard/templatetags/a4_candy_dashboard_tags.py
+++ b/apps/dashboard/templatetags/a4_candy_dashboard_tags.py
@@ -11,8 +11,6 @@ def closed_accordions(context, project_id):
     request = context['request']
     cookie = request.COOKIES.get('dashboard_projects_closed_accordions', '[]')
     ids = json.loads(unquote(cookie))
-    if project_id in ids:
-        ids.append(-1)
     return ids
 
 


### PR DESCRIPTION
project ids and module ids can overlap and therefore trigger wrong behavior. This PR stores project ids and module ids in separate lists.
closes #1951 