### PR TITLE
unload_warning: fix ckeditor pop-up error

### DIFF
--- a/adhocracy-plus/assets/js/unload_warning.js
+++ b/adhocracy-plus/assets/js/unload_warning.js
@@ -5,10 +5,14 @@
 
 document.addEventListener('DOMContentLoaded', () => {
   let submitted = false
-  const changeHandler = function () {
-    const target = event.target.id
-    if (target.includes('dashboardToggle')) {
-      submitted = true
+  const changeHandler = event => {
+    if (event.target === undefined) {
+      return
+    } else {
+      const target = event.target.id
+      if (target.includes('dashboardToggle')) {
+        submitted = true
+      }
     }
     window.addEventListener('beforeunload', (e) => {
       if (!submitted) {


### PR DESCRIPTION
the unload warning currently fails when you try to enter a url for the media embed. We don't need the warning for the pop-up anyway, so just skip it