### PR TITLE
config/urls: remove name of api/account

### DIFF
--- a/adhocracy-plus/config/urls.py
+++ b/adhocracy-plus/config/urls.py
@@ -89,7 +89,7 @@ urlpatterns = [
     re_path(r'^api/', include(likes_router.urls)),
     re_path(r'^api/', include(router.urls)),
     re_path(r'^api/login', obtain_auth_token, name='api-login'),
-    re_path(r'^api/account/', AccountViewSet.as_view(), name='account'),
+    re_path(r'^api/account/', AccountViewSet.as_view()),
     re_path(r'^upload/', user_is_project_admin(ck_views.upload),
             name='ckeditor_upload'),
     re_path(r'^browse/', never_cache(user_is_project_admin(ck_views.browse)),


### PR DESCRIPTION
This was interfering with https://github.com/liqd/adhocracy-plus/blob/1b9c351143aeb87f97f5b805ba2e3d21e8c8ab80/apps/account/urls.py#L8 and now the link to account settings lead to api :see_no_evil: 