### PR TITLE
Ks 2022 08 use png avatars in app

### DIFF
--- a/apps/users/models.py
+++ b/apps/users/models.py
@@ -139,6 +139,11 @@ class User(auth_models.AbstractBaseUser, auth_models.PermissionsMixin):
         number = self.pk % 5
         return static('images/avatar-{0:02d}.svg'.format(number))
 
+    @cached_property
+    def avatar_fallback_png(self):
+        number = self.pk % 5
+        return static('images/avatar-{0:02d}.png'.format(number))
+
     def get_short_name(self):
         return self.username
 

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
   "repository": "https://github.com/liqd/adhocracy-plus.git",
   "dependencies": {
     "@fortawesome/fontawesome-free": "5.15.4",
-    "adhocracy4": "git+https://github.com/liqd/adhocracy4#aplus-v2207",
+    "adhocracy4": "git+https://github.com/liqd/adhocracy4#f244c8d02b5db4eb9de588d81f2c183029ac519c",
     "autoprefixer": "10.4.8",
     "bootstrap": "5.1.3",
     "classnames": "2.3.1",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+https://github.com/liqd/adhocracy4.git@aplus-v2207#egg=adhocracy4
+git+https://github.com/liqd/adhocracy4.git@f244c8d02b5db4eb9de588d81f2c183029ac519c#egg=adhocracy4
 
 # Additional requirements
 bcrypt==3.2.2


### PR DESCRIPTION
depends on https://github.com/liqd/adhocracy4/pull/1175 and hash needs update after merge

with this, avatar fallbacks should show in the app