### PR TITLE
[#6750] a4dashboard: add communication form

### DIFF
--- a/adhocracy-plus/templates/a4dashboard/base_dashboard.html
+++ b/adhocracy-plus/templates/a4dashboard/base_dashboard.html
@@ -14,14 +14,14 @@
             {% else %}
               <div class="dashboard-nav__logo-link">
                 <a class="font-weight-bold" href="{% url 'organisation' organisation_slug=ORGANISATION.slug %}">
-                  <i class="fas fa-home pt-2" aria-label="{{ ORGANISATION.name }} {% trans 'Home' %}" role="img"></i>
+                  <i class="fas fa-home pt-2" aria-label="{{ ORGANISATION.name }} {% translate 'Home' %}" role="img"></i>
                 </a>
               </div>
             {% endif %}
             <div class="dropdown">
                 {% if view.other_organisations_of_user %}
                     <button
-                            title="{% trans 'Organisations' %}"
+                            title="{% translate 'Organisations' %}"
                             type="button"
                             class="dropdown-toggle btn btn--none btn--small"
                             data-bs-toggle="dropdown"
@@ -48,20 +48,24 @@
             </div>
           </div>
 
-            <nav class="d-none d-sm-inline-block" aria-label="{% trans 'Dashboard' %}">
-                <a href="{% url 'a4dashboard:project-list' organisation_slug=view.organisation.slug %}"
+            {% url 'a4dashboard:project-list' organisation_slug=view.organisation.slug as project_list %}
+            {% url 'a4dashboard:newsletter-create' organisation_slug=view.organisation.slug as newsletter_create %}
+            {% url 'a4dashboard:organisation-settings' organisation_slug=view.organisation.slug as organisation_settings %}
+
+            <nav class="d-none d-sm-inline-block" aria-label="{% translate 'Dashboard' %}">
+                <a href="{{ project_list }}"
                    class="tab {% if view.menu_item == 'project' %}active{% endif %}">
-                    {% trans 'Participation projects' %}
+                    {% translate 'Participation projects' %}
                 </a>
-                <a href="{% url 'a4dashboard:newsletter-create' organisation_slug=view.organisation.slug %}"
-                   class="tab {% if view.menu_item == 'newsletter' %}active{% endif %}">
-                    {% trans 'Newsletter' %}
+                <a href="{{ newsletter_create }}"
+                   class="tab {% if view.menu_item == 'communication' %}active{% endif %}">
+                    {% translate 'Communication' %}
                 </a>
                 {% has_perm 'a4_candy_organisations.change_organisation' request.user view.organisation as user_may_change_organisation %}
                 {% if user_may_change_organisation %}
-                <a href="{% url 'a4dashboard:organisation-settings' organisation_slug=view.organisation.slug %}"
+                <a href="{{ organisation_settings }}"
                    class="tab {% if view.menu_item == 'organisation' %}active{% endif %}">
-                    {% trans 'Organisation settings' %}
+                    {% translate 'Organisation settings' %}
                 </a>
                 {% endif %}
             </nav>
@@ -76,14 +80,12 @@
                       role="button"
                       aria-expanded="false"
                       data-bs-toggle="tab">
-                      {% url 'a4dashboard:project-list' organisation_slug=view.organisation.slug as project_list %}
-                      {% url 'a4dashboard:newsletter-create' organisation_slug=view.organisation.slug as newsletter_create %}
                       {% if request.path ==  project_list %}
-                        {% trans 'Participation projects' %}
+                        {% translate 'Participation projects' %}
                       {% elif request.path == newsletter_create %}
-                        {% trans 'Newsletter' %}
+                        {% translate 'Communication' %}
                       {% else %}
-                        {% trans 'Organisation settings' %}
+                        {% translate 'Organisation settings' %}
                       {% endif %}
                       <i class="fa fa-caret-down" aria-hidden="true"></i>
                   </a>
@@ -91,19 +93,19 @@
                       <a
                           class="dropdown-item"
                           href="{{ project_list }}">
-                          {% trans 'Participation projects' %}
+                          {% translate 'Participation projects' %}
                       </a>
                       <a
                           class="dropdown-item"
                           href="{{ newsletter_create }}">
-                          {% trans 'Newsletter' %}
+                          {% translate 'Communication' %}
                       </a>
                       {% has_perm 'a4_candy_organisations.change_organisation' request.user view.organisation as user_may_change_organisation %}
                       {% if user_may_change_organisation %}
                       <a
                           class="dropdown-item"
-                          href="{% url 'a4dashboard:organisation-settings' organisation_slug=view.organisation.slug %}">
-                          {% trans 'Organisation settings' %}
+                          href="{{ organisation_settings }}">
+                          {% translate 'Organisation settings' %}
                       </a>
                       {% endif %}
                   </div>

--- a/adhocracy-plus/templates/a4dashboard/communication_form_base.html
+++ b/adhocracy-plus/templates/a4dashboard/communication_form_base.html
@@ -1,0 +1,35 @@
+{% extends "a4dashboard/base_dashboard.html" %}
+{% load i18n rules wagtailsettings_tags %}
+{% get_settings %}
+
+{% block dashboard_content %}
+<div class="row">
+    <nav class="col-md-3" aria-label="{% translate '' %}">
+        <div class="dashboard-nav">
+            <div class="dashboard-nav__dropdown">
+                {% translate "Communication" %}
+            </div>
+            <ul class="dashboard-nav__pages">
+                <li class="dashboard-nav__page">
+                    <a href="{% url 'a4dashboard:newsletter-create' organisation_slug=view.organisation.slug %}"
+                        class="dashboard-nav__item dashboard-nav__item--interactive {% if request.resolver_match.url_name == 'newsletter-create' %}is-active{% endif %}">
+                        {% translate "Newsletter" %}
+
+                    </a>
+                </li>
+                <li class="dashboard-nav__page">
+                    <a href="{% url 'a4dashboard:communication-content' organisation_slug=view.organisation.slug %}"
+                        class="dashboard-nav__item dashboard-nav__item--interactive {% if request.resolver_match.url_name|slice:':21' == 'communication-content' %}is-active{% endif %}">
+                        {% translate "Social Media" %}
+                    </a>
+                </li>
+            </ul>
+        </div>
+    </nav>
+
+
+    <div class="col-md-9">
+        {% block communication_form %}{% endblock %}
+    </div>
+</div>
+{% endblock %}

--- a/adhocracy-plus/templates/a4images/image_upload_widget_simple.html
+++ b/adhocracy-plus/templates/a4images/image_upload_widget_simple.html
@@ -1,0 +1,30 @@
+{% load i18n %}
+<div class="upload-wrapper form-control-upload">
+    <div class="upload-wrapper__fields">
+        {{ file_input }}
+        {{ text_input }}
+        <div class="upload-wrapper__action-parent">
+        {% if has_image_set and not is_required %}
+            <label for="{{ checkbox_id }}"
+                class="upload-wrapper__action btn btn--danger"
+                title="{% trans 'Remove the picture' %}">
+                <i class="far fa-trash-alt" aria-label="{% trans 'Remove the picture' %}"></i>
+            </label>
+        {% else %}
+            <label for="{{ id }}"
+                class="upload-wrapper__action btn btn--primary-filled"
+                title="{% trans 'Upload a picture' %}">
+                <i class="fas fa-cloud-upload-alt" aria-label="{% trans 'Upload a picture' %}"></i>
+            </label>
+        {% endif %}
+        </div>
+    </div>
+    <div class="form-{{ id }} upload-wrapper__preview col-sm-3">
+        {{ checkbox_input }}
+        <img id="{{ file_id }}"
+             src="{% if has_image_set %}{{ file_url }}{% else %}data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs={% endif %}"
+             data-upload-preview="{{ id }}"
+             alt=""
+        >
+    </div>
+</div>

--- a/apps/contrib/widgets.py
+++ b/apps/contrib/widgets.py
@@ -3,6 +3,7 @@ from django.template.loader import render_to_string
 from django.utils.translation import gettext_lazy as _
 
 from adhocracy4.filters.widgets import OrderingWidget
+from adhocracy4.images.widgets import ImageInputWidget
 
 
 class Select2Mixin:
@@ -57,3 +58,13 @@ class AplusOrderingWidget(OrderingWidget):
     # FIXME: only because https://github.com/liqd/adhocracy-plus/issues/1659
     # test and remove from time to time
     label = _('Ordering')
+
+
+class ImageInputWidgetSimple(ImageInputWidget):
+    """Almost same as ImageInputWidget.
+
+    Only difference is that it is not showing info box about image
+    only being uploaded after clicking save.
+    """
+
+    widget_template_name = 'a4images/image_upload_widget_simple.html'

--- a/apps/dashboard/urls.py
+++ b/apps/dashboard/urls.py
@@ -25,7 +25,7 @@ urlpatterns = [
     re_path(r'^delete/module/(?P<slug>[-\w_]+)/$',
             views.ModuleDeleteView.as_view(),
             name='module-delete'),
-    path('newsletters/create/',
+    path('communication/newsletters/create/',
          newsletter_views.DashboardNewsletterCreateView.as_view(),
          name='newsletter-create'),
     path('settings/',
@@ -34,6 +34,14 @@ urlpatterns = [
     path('settings/legal-information',
          organisation_views.DashboardLegalInformationUpdateView.as_view(),
          name='organisation-legal-information'),
+    path('communication/content/create/',
+         organisation_views.DashboardCommunicationProjectChoiceView.as_view(),
+         name='communication-content'),
+    path('communication/content/create/<slug:project_slug>/'
+         'format/<int:format>/',
+         organisation_views.DashboardCommunicationContentCreateView.as_view(),
+         name='communication-content-create'),
+
 ]
 
 # a4 dashboard urls without organisation slug

--- a/apps/newsletters/templates/a4_candy_newsletters/restricted_newsletter_dashboard_form.html
+++ b/apps/newsletters/templates/a4_candy_newsletters/restricted_newsletter_dashboard_form.html
@@ -1,11 +1,11 @@
-{% extends "a4dashboard/base_dashboard.html" %}
+{% extends "a4dashboard/communication_form_base.html" %}
 {% load i18n %}
 
-{% block title %}{% trans "Newsletter" %} &mdash; {{ block.super }}{% endblock%}
+{% block title %}{% translate "Newsletter" %} &mdash; {{ block.super }}{% endblock%}
 
-{% block dashboard_content %}
-<div class="col-md-10 col-lg-8 offset-md-1 offset-lg-2">
-    <h1>{% trans "Create Newsletter" %}</h1>
+{% block communication_form %}
+<div class="col-md-9">
+    <h1>{% translate "Create Newsletter" %}</h1>
 
     <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
         {% csrf_token %}
@@ -26,8 +26,8 @@
         <input type="hidden" id="{{ form.organisation.id_for_label}}" name="{{form.organisation.html_name}}" value="{{view.organisation.id}}" />
 
         <div class="d-flex justify-content-end mb-3">
-            <a href="{% url 'a4dashboard:project-list' organisation_slug=view.organisation.slug %}" class="btn btn--secondary me-2">{% trans 'Cancel'%}</a>
-            <input type="submit" class="btn btn--primary" name="send" value="{% trans 'Send'%}" />
+            <a href="{% url 'a4dashboard:project-list' organisation_slug=view.organisation.slug %}" class="btn btn--secondary me-2">{% translate 'Cancel'%}</a>
+            <input type="submit" class="btn btn--primary" name="send" value="{% translate 'Send'%}" />
         </div>
     </form>
     {{ form.media }}

--- a/apps/newsletters/views.py
+++ b/apps/newsletters/views.py
@@ -63,7 +63,7 @@ class NewsletterCreateView(rules_mixins.PermissionRequiredMixin,
 
 class DashboardNewsletterCreateView(a4dashboard_mixins.DashboardBaseMixin,
                                     NewsletterCreateView):
-    menu_item = 'newsletter'
+    menu_item = 'communication'
     form_class = RestrictedNewsletterForm
     permission_required = 'a4projects.add_project'
     template_name = ('a4_candy_newsletters/'

--- a/apps/organisations/forms.py
+++ b/apps/organisations/forms.py
@@ -7,8 +7,8 @@ from django.core.exceptions import ValidationError
 from django.utils.translation import gettext_lazy as _
 
 from adhocracy4 import transforms
-from adhocracy4.images.widgets import ImageInputWidget
 from apps.cms.settings import helpers
+from apps.contrib.widgets import ImageInputWidgetSimple
 from apps.organisations.models import OrganisationTranslation
 from apps.projects.models import Project
 
@@ -252,7 +252,7 @@ class CommunicationContentCreationForm(forms.Form):
         self.fields['image'] = forms.ImageField(
             label=_('Picture Upload'),
             required=True,
-            widget=ImageInputWidget,
+            widget=ImageInputWidgetSimple,
             help_text=_('The picture will be displayed in the sharepic. It '
                         'must be min. {} pixel wide and {} pixel tall. '
                         'Allowed file formats are png, jpeg, gif. The file '

--- a/apps/organisations/templates/a4_candy_organisations/communication_form_social_media.html
+++ b/apps/organisations/templates/a4_candy_organisations/communication_form_social_media.html
@@ -1,0 +1,37 @@
+{% extends "a4dashboard/communication_form_base.html" %}
+{% load i18n %}
+
+{% block title %}{% translate "Settings" %} &mdash; {{ block.super }}{% endblock %}
+
+{% block communication_form %}
+    <div class="col-md-10">
+        <h1>{% translate "Create Content" %}</h1>
+
+        <form enctype="multipart/form-data" action="{% url 'a4dashboard:communication-content' organisation_slug=organisation.slug %}" method="post">
+            {% csrf_token %}
+            {% include 'a4_candy_contrib/includes/form_field.html' with field=project_form.format %}
+            {% include 'a4_candy_contrib/includes/form_field.html' with field=project_form.project %}
+            <div class="d-flex justify-content-end mb-3">
+                <button type="submit" class="btn btn--primary">{% translate 'Select' %}</button>
+            </div>
+        </form>
+        {{ project_form.media }}
+
+
+        <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
+            {% csrf_token %}
+            {% if content_form %}
+            {% include 'a4_candy_contrib/includes/form_field.html' with field=content_form.title %}
+            {% include 'a4_candy_contrib/includes/form_field.html' with field=content_form.description %}
+            {% include 'a4_candy_contrib/includes/form_field.html' with field=content_form.image %}
+            <div class="d-flex justify-content-end mb-3">
+                <button type="submit" class="btn btn--primary">{% translate 'Generate' %}</button>
+            </div>
+            {% endif %}
+            {% if image_preview %}
+                there is an image in the context
+            {% endif %}
+        </form>
+        {{ form.media }}
+    </div>
+{% endblock %}

--- a/apps/organisations/views.py
+++ b/apps/organisations/views.py
@@ -10,6 +10,8 @@ from django.utils.translation import gettext_lazy as _
 from django.views import generic
 from django.views.generic import DetailView
 from PIL import Image
+from PIL import ImageDraw
+from PIL import ImageFont
 
 from adhocracy4.dashboard import mixins as a4dashboard_mixins
 from apps.projects.models import Project
@@ -217,8 +219,41 @@ class DashboardCommunicationContentCreateView(
         return self.render_to_response(context)
 
     def generate_image(self, data):
-        image = Image.new('RGB', (60, 30), color='red')
+        # Dummy images
+        image = Image.new('RGB', (304, 192), color='red')
         image.save(settings.MEDIA_ROOT + '/images/tmp_image.png')
+        logo1 = Image.new('RGB', (100, 10), color='blue')
+        logo2 = Image.new('RGB', (100, 10), color='green')
+
+        # Adding padding
+        right = 0
+        left = 0
+        top = 64
+        bottom = 48
+        width, height = image.size
+        new_width = width + right + left
+        new_height = height + top + bottom
+        result = Image.new(
+            image.mode, (new_width, new_height), (255, 255, 255))
+        result.paste(image, (left, top))
+
+        # Adding writting
+        # Image is converted into editable form using Draw function and
+        # assigned to d1
+        d1 = ImageDraw.Draw(result)
+        # Text location, color and font
+        font = ImageFont.truetype(
+            "adhocracy-plus/assets/fonts/SourceSansPro-Semibold.otf", 20)
+        fontsm = ImageFont.truetype(
+            "adhocracy-plus/assets/fonts/SourceSansPro-Regular.otf", 12)
+        d1.text((16, 12), data['title'], fill=(0, 0, 0), font=font)
+        d1.text((16, 37), data['description'], fill=(0, 0, 0), font=fontsm)
+
+        # Adding logos
+        result.paste(logo1, (46, 277))
+        result.paste(logo2, (157, 277))
+
+        result.show()
         return image
 
     @property

--- a/apps/organisations/views.py
+++ b/apps/organisations/views.py
@@ -3,11 +3,16 @@ import json
 from django.conf import settings
 from django.contrib.messages.views import SuccessMessageMixin
 from django.core.exceptions import ImproperlyConfigured
+from django.shortcuts import get_object_or_404
+from django.shortcuts import redirect
+from django.urls import reverse
 from django.utils.translation import gettext_lazy as _
 from django.views import generic
 from django.views.generic import DetailView
+from PIL import Image
 
 from adhocracy4.dashboard import mixins as a4dashboard_mixins
+from apps.projects.models import Project
 
 from . import forms
 from .models import Organisation
@@ -117,3 +122,109 @@ class DashboardLegalInformationUpdateView(
 
     def get_success_url(self):
         return self.request.path
+
+
+class DashboardCommunicationProjectChoiceView(
+        a4dashboard_mixins.DashboardBaseMixin,
+        generic.FormView):
+
+    menu_item = 'communication'
+    form_class = forms.CommunicationProjectChoiceForm
+    permission_required = 'a4_candy_organisations.change_organisation'
+    template_name = 'a4_candy_organisations/' \
+                    'communication_form_social_media.html'
+    slug_url_kwarg = 'organisation_slug'
+
+    def get_permission_object(self):
+        return self.organisation
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        kwargs['organisation'] = self.organisation
+        return kwargs
+
+    def form_valid(self, form):
+        """If the form is valid, redirect to the content creation form."""
+        project = form.cleaned_data['project']
+        img_format = form.cleaned_data['format']
+        return redirect(
+            reverse('a4dashboard:communication-content-create',
+                    kwargs={'organisation_slug': self.organisation.slug,
+                            'project_slug': project.slug,
+                            'format': int(img_format)
+                            }))
+
+    def get_context_data(self, **kwargs):
+        """Insert the form as project_form into the context dict."""
+        kwargs = super().get_context_data(**kwargs)
+        if 'form' in kwargs:
+            kwargs.pop('form')
+        if 'project_form' not in kwargs:
+            kwargs['project_form'] = self.get_form()
+        if 'organisation' not in kwargs:
+            kwargs['organisation'] = self.organisation
+
+        return kwargs
+
+
+class DashboardCommunicationContentCreateView(
+        a4dashboard_mixins.DashboardBaseMixin,
+        generic.FormView):
+
+    menu_item = 'communication'
+    form_class = forms.CommunicationContentCreationForm
+    permission_required = 'a4_candy_organisations.change_organisation'
+    template_name = 'a4_candy_organisations/' \
+                    'communication_form_social_media.html'
+    slug_url_kwarg = 'organisation_slug'
+
+    def get_permission_object(self):
+        return self.organisation
+
+    def get_success_url(self):
+        return self.request.path
+
+    def get_form_kwargs(self):
+        kwargs = super().get_form_kwargs()
+        if not self.request.POST:
+            kwargs['project'] = self.project
+        kwargs['format'] = self.format
+
+        return kwargs
+
+    def get_context_data(self, **kwargs):
+        if 'form' in kwargs:
+            kwargs.pop('form')
+        if 'content_form' not in kwargs:
+            kwargs['content_form'] = self.get_form()
+        if 'project_form' not in kwargs:
+            project_form = forms.CommunicationProjectChoiceForm(
+                initial={'project': self.project,
+                         'format': self.format},
+                organisation=self.organisation
+            )
+            kwargs['project_form'] = project_form
+        if 'organisation' not in kwargs:
+            kwargs['organisation'] = self.organisation
+
+        return super().get_context_data(**kwargs)
+
+    def form_valid(self, form):
+        data = form.cleaned_data
+        img = self.generate_image(data)
+        context = self.get_context_data()
+        context['image_preview'] = img
+        return self.render_to_response(context)
+
+    def generate_image(self, data):
+        image = Image.new('RGB', (60, 30), color='red')
+        image.save(settings.MEDIA_ROOT + '/images/tmp_image.png')
+        return image
+
+    @property
+    def project(self):
+        return get_object_or_404(Project, slug=self.kwargs['project_slug'])
+
+    @property
+    def format(self):
+        return self.kwargs['format']


### PR DESCRIPTION
The last commit depends on https://github.com/liqd/adhocracy4/pull/1289, so that need to be merged first and the hash added.

There are still some things that need to be done:
- checkboxes for logos
- image creation with input data and for different templates
- preview/download of generated image
- tests

But maybe this is a state that could be merged and we can on from there?