### PR TITLE
notifications: add moderation specific emails

### DIFF
--- a/apps/contrib/management/commands/send_test_emails.py
+++ b/apps/contrib/management/commands/send_test_emails.py
@@ -2,6 +2,7 @@ from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.contenttypes.models import ContentType
 from django.core.management.base import BaseCommand
+from django.urls import reverse
 
 from adhocracy4.actions.models import Action
 from adhocracy4.actions.verbs import Verbs
@@ -13,6 +14,7 @@ from adhocracy4.reports.models import Report
 from apps.cms.contacts.models import CustomFormSubmission
 from apps.cms.contacts.models import FormPage
 from apps.ideas.models import Idea
+from apps.moderatorfeedback.models import ModeratorCommentFeedback
 from apps.notifications import emails as notification_emails
 from apps.offlineevents.models import OfflineEvent
 from apps.projects import models as project_models
@@ -58,7 +60,6 @@ class Command(BaseCommand):
     """
 
     def handle(self, *args, **options):
-
         self.user = User.objects.get(email=options["email"])
 
         self._send_notifications_create_idea()
@@ -80,6 +81,9 @@ class Command(BaseCommand):
         self._send_allauth_email_confirmation()
         self._send_allauth_password_reset()
         self._send_allauth_unknown_account()
+
+        self._send_notification_blocked_comment()
+        self._send_notification_moderator_comment_feedback()
 
     def _send_notifications_create_idea(self):
         # Send notification for a newly created item
@@ -332,4 +336,50 @@ class Command(BaseCommand):
             receiver=[self.user],
             template_name="account/email/unknown_account",
             **context
+        )
+
+    def _send_notification_blocked_comment(self):
+        # Send notification when comment is blocked
+        comment = Comment.objects.first()
+        if not comment:
+            self.stderr.write("At least one comment is required")
+            return
+        netiquette_url = ""
+        organisation = comment.project.organisation
+        if organisation.netiquette:
+            netiquette_url = reverse(
+                "organisation-netiquette",
+                kwargs={"organisation_slug": organisation.slug},
+            )
+        discussion_url = comment.module.get_detail_url
+        if comment.parent_comment.exists():
+            discussion_url = (
+                comment.parent_comment.first().content_object.get_absolute_url()
+            )
+        elif comment.content_object.get_absolute_url():
+            discussion_url = comment.content_object.get_absolute_url()
+        TestEmail.send(
+            comment,
+            module=comment.module,
+            project=comment.project,
+            netiquette_url=netiquette_url,
+            discussion_url=discussion_url,
+            receiver=[self.user],
+            template_name=notification_emails.NotifyCreatorOnModeratorBlocked.template_name,
+        )
+
+    def _send_notification_moderator_comment_feedback(self):
+        # Send notification when moderator comment feedback is added
+        feedback = ModeratorCommentFeedback.objects.first()
+        if not feedback:
+            self.stderr.write("At least one moderator comment feedback is required")
+            return
+        TestEmail.send(
+            feedback,
+            project=feedback.comment.project,
+            moderator_name=feedback.creator.username,
+            moderator_feedback=feedback.feedback_text,
+            comment_url=feedback.comment.get_absolute_url(),
+            receiver=[self.user],
+            template_name=notification_emails.NotifyCreatorOnModeratorCommentFeedback.template_name,
         )

--- a/apps/notifications/emails.py
+++ b/apps/notifications/emails.py
@@ -118,6 +118,28 @@ class NotifyCreatorOnModeratorBlocked(Email):
         return context
 
 
+class NotifyCreatorOnModeratorCommentFeedback(Email):
+    template_name = (
+        "a4_candy_notifications/emails" "/notify_creator_on_moderator_comment_feedback"
+    )
+
+    def get_organisation(self):
+        return self.object.project.organisation
+
+    def get_receivers(self):
+        receivers = [self.object.comment.creator]
+        receivers = _exclude_notifications_disabled(receivers)
+        return receivers
+
+    def get_context(self):
+        context = super().get_context()
+        context["project"] = self.object.project
+        context["moderator_name"] = self.object.creator.username
+        context["moderator_feedback"] = self.object.feedback_text
+        context["comment_url"] = self.object.comment.get_absolute_url()
+        return context
+
+
 class NotifyModeratorsEmail(Email):
     template_name = "a4_candy_notifications/emails/notify_moderator"
 

--- a/apps/notifications/signals.py
+++ b/apps/notifications/signals.py
@@ -7,6 +7,7 @@ from adhocracy4.actions.verbs import Verbs
 from adhocracy4.dashboard import signals as dashboard_signals
 from adhocracy4.follows.models import Follow
 from adhocracy4.projects.models import Project
+from apps.moderatorfeedback.models import ModeratorCommentFeedback
 
 from . import emails
 
@@ -44,6 +45,11 @@ def send_project_created_notifications(**kwargs):
 @receiver(signals.post_delete, sender=Project)
 def send_project_deleted_notifications(sender, instance, **kwargs):
     emails.NotifyInitiatorsOnProjectDeletedEmail.send_no_object(instance)
+
+
+@receiver(signals.post_save, sender=ModeratorCommentFeedback)
+def send_moderator_comment_feedback_notification(instance, **kwargs):
+    emails.NotifyCreatorOnModeratorCommentFeedback.send(instance)
 
 
 @receiver(signals.m2m_changed, sender=Project.moderators.through)

--- a/apps/notifications/templates/a4_candy_notifications/emails/notify_creator_on_moderator_blocked.en.email
+++ b/apps/notifications/templates/a4_candy_notifications/emails/notify_creator_on_moderator_blocked.en.email
@@ -1,0 +1,45 @@
+{% extends 'email_base.'|add:part_type %}
+{% load class_name i18n %}
+
+{% block subject %}
+{% blocktranslate %}Your contribution was deleted{% endblocktranslate %}
+{% endblock %}
+
+{% block headline %}
+{% blocktranslate %}Your contribution was deleted{% endblocktranslate %}
+{% endblock  %}
+
+{% block sub-headline %}
+<div style="text-transform: uppercase; margin-bottom: 2em">{{ project.name }}</div>
+{% endblock  %}
+
+
+{% block greeting %}
+{% blocktranslate with receiver_name=receiver.username %}Hello <strong>{{ receiver_name }}</strong>,{% endblocktranslate %}
+{% endblock %}
+
+{% block content %}
+{% blocktranslate with project_name=project.name %}Your contribution in the project <strong>"{{ project_name }}"</strong> was deleted by the moderator.{% endblocktranslate %} {{ netiquette_link | safe }} {% blocktranslate %}Please pay attention to the basic rules when writing contributions. In this way we create a pleasant atmosphere for an open exchange and achieve good results.{% endblocktranslate %}
+
+{% blocktranslate %}Thank you very much!{% endblocktranslate %}
+
+<strong>
+    {% blocktranslate %}Your contribution:{% endblocktranslate %}
+</strong>
+
+<p style="margin-bottom: 1em">
+    {{ comment.comment }}
+</p>
+{% endblock %}
+
+{% block cta_url %}
+{{ email.get_host }}{{ discussion_url }}
+{% endblock %}
+
+{% block cta_label %}
+{% blocktranslate %}Show discussion{% endblocktranslate %}
+{% endblock %}
+
+{% block reason %}
+{% blocktranslate with receiver_mail=receiver.email %}This email was sent to {{ receiver_mail }}. This email was sent to you because of your participation in the project.{% endblocktranslate %} {{ account_link | safe }}
+{% endblock %}

--- a/apps/notifications/templates/a4_candy_notifications/emails/notify_creator_on_moderator_comment_feedback.en.email
+++ b/apps/notifications/templates/a4_candy_notifications/emails/notify_creator_on_moderator_comment_feedback.en.email
@@ -1,0 +1,35 @@
+{% extends 'email_base.'|add:part_type %}
+{% load class_name i18n %}
+
+{% block subject %}
+{% blocktranslate %}Feedback of the moderation{% endblocktranslate %}
+{% endblock %}
+
+{% block headline %}
+{% blocktranslate %}Feedback of the moderation{% endblocktranslate %}
+{% endblock  %}
+
+{% block sub-headline %}
+{{ project_name }}
+{% endblock  %}
+
+
+{% block greeting %}{% blocktranslate with receiver_name=receiver.username %}Hello {{ receiver_name }},{% endblocktranslate %}{% endblock %}
+
+{% block content %}
+{% blocktranslate with project_name=project.name %}the moderator {{ moderator_name }} of the project {{ project_name }} gave feedback on your contribution:{% endblocktranslate %}
+
+<i>"{{ moderator_feedback }}"</i>
+
+{% blocktranslate %}Here you can find your contribution:{% endblocktranslate %}
+{% endblock %}
+
+{% block cta_url %}{{ email.get_host }}{{ comment_url }}{% endblock %}
+
+{% block cta_label %}
+{% blocktranslate %}Show contribution{% endblocktranslate %}
+{% endblock %}
+
+{% block reason %}
+{% blocktranslate with receiver_mail=receiver.email %}This email was sent to {{ receiver_mail }}. This email was sent to you because of your participation in the project.{% endblocktranslate %} {{ account_link | safe }}
+{% endblock %}


### PR DESCRIPTION
I actually could not test this, because I could neither make the send_test_emails work, nor could I trigger an email.. could someone check if this works? Maybe its just my setup? 
Both emails are sent to comment creator, one when comment is being blocked, the other when statement has been added to the comment..

Supposed to fix https://sentry.liqd.net/organizations/liqd/issues/3171/