### PR TITLE
badge.scss: making sure bs and a4 classes are not overwritten by .badge

### DIFF
--- a/adhocracy-plus/assets/scss/components/_badge.scss
+++ b/adhocracy-plus/assets/scss/components/_badge.scss
@@ -1,4 +1,6 @@
-.badge {
+// FIXME: this is a workaround to make 'badge' usage in a4 work
+// should change badge to label in a4
+.badge:not(.a4-comments__category__text) {
     display: inline-block;
     background-color: $text-color;
     color: contrast-color($text-color);


### PR DESCRIPTION
this fixes the badge issue in debate module, mentioned by @lthueer here:
https://github.com/liqd/adhocracy-plus/issues/2364#issuecomment-1521960083
