### PR TITLE
Fix #2341: Replace liqd/django-autoslug dependency to upstream 

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -16,7 +16,7 @@ urllib3==1.26.15
 # Inherited a4-core requirements
 Django==3.2.19
 django-allauth==0.54.0
-git+https://github.com/liqd/django-autoslug.git@liqd2212#egg=django-autoslug
+django-autoslug==1.9.9
 django-background-tasks==1.2.5
 django-ckeditor==6.5.1
 django-filter==22.1


### PR DESCRIPTION
## Overview

This PR fixes #2341 by replacing the [forked/edited django-autoslug](https://github.com/liqd/django-autoslug) (introduced via #2188) with its original upstream.

This is possible now as the changes made on the forked repo are [merged and released upstream](https://github.com/justinmayer/django-autoslug/pull/79#issuecomment-1494295682).

## Manual testing

**Able to install the latest upstream django-autoslug via pip**
![image](https://github.com/liqd/adhocracy-plus/assets/16653571/045d5239-1b15-4658-a149-2a340b5bfdde)

**Able to run the server with the latest version of  django-autoslug**
![image](https://github.com/liqd/adhocracy-plus/assets/16653571/9b24c758-17a9-490c-ab4f-624f1b5be086)
