### PR TITLE
Fix #2064: Check catcha url exists in signup form

### DIFF
--- a/adhocracy-plus/config/settings/base.py
+++ b/adhocracy-plus/config/settings/base.py
@@ -548,3 +548,7 @@ CSP_DEFAULT_SRC = ["'self'", "'unsafe-inline'", "'unsafe-eval'", "data:", "blob:
 SITE_ID = 1  # overwrite this in local.py if needed
 
 DEFAULT_AUTO_FIELD = "django.db.models.AutoField"
+
+# Add a Captcheck captcha URL in the production server's local.py to use it
+# Captcha software we use: https://source.netsyms.com/Netsyms/Captcheck
+CAPTCHA_URL = ""

--- a/adhocracy-plus/templates/account/signup.html
+++ b/adhocracy-plus/templates/account/signup.html
@@ -52,7 +52,9 @@
             <input type="hidden" name="{{ redirect_field_name }}" value="{{ redirect_field_value }}"/>
         {% endif %}
 
-        {% include 'a4_candy_contrib/includes/form_field.html' with field=form.captcha tabindex=0 %}
+        {% if form.captcha %}
+          {% include 'a4_candy_contrib/includes/form_field.html' with field=form.captcha tabindex=0 %}
+        {% endif %}
 
         <p>
         {% blocktranslate with data_protection_url=settings.a4_candy_cms_settings.ImportantPages.data_protection_policy.url platformname=settings.a4_candy_cms_settings.OrganisationSettings.platform_name %}

--- a/apps/cms/contacts/models.py
+++ b/apps/cms/contacts/models.py
@@ -1,3 +1,4 @@
+from django.conf import settings
 from django.contrib import messages
 from django.db import models
 from django.shortcuts import redirect
@@ -26,14 +27,15 @@ class FormField(AbstractFormField):
 class WagtailCaptchaFormBuilder(FormBuilder):
     @property
     def formfields(self):
-        # Add captcha to formfields property
         fields = super().formfields
-        fields["captcha"] = CaptcheckCaptchaField(
-            label=_("I am not a robot"),
-            help_text=_(
-                "If you are having difficulty please contact" "us, details adjacent"
-            ),
-        )
+        # Add captcha to formfields property if the URL exists in settings
+        if hasattr(settings, "CAPTCHA_URL") and settings.CAPTCHA_URL:
+            fields["captcha"] = CaptcheckCaptchaField(
+                label=_("I am not a robot"),
+                help_text=_(
+                    "If you are having difficulty please contact" "us, details adjacent"
+                ),
+            )
 
         return fields
 

--- a/apps/contrib/templates/a4_candy_contrib/includes/form_field.html
+++ b/apps/contrib/templates/a4_candy_contrib/includes/form_field.html
@@ -17,7 +17,7 @@
         <div class="widget widget--{{ field|widget_type }}">
           {% with describedby="hint_"|add:field.id_for_label %}
           {% if field.errors %}
-                {% render_field field aria-invalid="true" aria-describedby=describedby %}
+              {% render_field field aria-invalid="true" aria-describedby=describedby %}
           {% else %}
             {% render_field field aria-describedby=describedby %}
           {% endif %}

--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -57,9 +57,12 @@ class DefaultSignupForm(SignupForm):
         self.fields["email"].widget.attrs["autocomplete"] = "username"
         self.fields["password1"].widget.attrs["autocomplete"] = "new-password"
         self.fields["password2"].widget.attrs["autocomplete"] = "new-password"
-        self.fields["captcha"].help_text = helpers.add_email_link_to_helptext(
-            self.fields["captcha"].help_text, CAPTCHA_HELP
-        )
+        if not hasattr(settings, "CAPTCHA_URL") or settings.CAPTCHA_URL is None:
+            del self.fields["captcha"]
+        else:
+            self.fields["captcha"].help_text = helpers.add_email_link_to_helptext(
+                self.fields["captcha"].help_text, CAPTCHA_HELP
+            )
 
     def save(self, request):
         user = super().save(request)

--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -57,7 +57,7 @@ class DefaultSignupForm(SignupForm):
         self.fields["email"].widget.attrs["autocomplete"] = "username"
         self.fields["password1"].widget.attrs["autocomplete"] = "new-password"
         self.fields["password2"].widget.attrs["autocomplete"] = "new-password"
-        if not hasattr(settings, "CAPTCHA_URL") or not settings.CAPTCHA_URL:
+        if not (hasattr(settings, "CAPTCHA_URL") and settings.CAPTCHA_URL):
             del self.fields["captcha"]
         else:
             self.fields["captcha"].help_text = helpers.add_email_link_to_helptext(

--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -57,7 +57,7 @@ class DefaultSignupForm(SignupForm):
         self.fields["email"].widget.attrs["autocomplete"] = "username"
         self.fields["password1"].widget.attrs["autocomplete"] = "new-password"
         self.fields["password2"].widget.attrs["autocomplete"] = "new-password"
-        if not hasattr(settings, "CAPTCHA_URL") or settings.CAPTCHA_URL is None:
+        if not hasattr(settings, "CAPTCHA_URL") or not settings.CAPTCHA_URL:
             del self.fields["captcha"]
         else:
             self.fields["captcha"].help_text = helpers.add_email_link_to_helptext(

--- a/changelog/2064.md
+++ b/changelog/2064.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- captcha becomes optional depending on project settings (#2449)

--- a/tests/users/test_signup.py
+++ b/tests/users/test_signup.py
@@ -98,3 +98,23 @@ def test_signup_user_when_captcha_is_none(client):
     assert resp.status_code == 302
     user = User.objects.get()
     assert user.get_newsletters
+
+
+@override_settings()
+@pytest.mark.django_db
+def test_signup_user_when_not_captcha(client):
+    settings.CAPTCHA_URL = ""
+    resp = client.post(
+        reverse("account_signup"),
+        {
+            "username": "dauser",
+            "email": "mail@example.com",
+            "get_newsletters": "on",
+            "password1": "password",
+            "password2": "password",
+            "terms_of_use": "on",
+        },
+    )
+    assert resp.status_code == 302
+    user = User.objects.get()
+    assert user.get_newsletters

--- a/tests/users/test_signup.py
+++ b/tests/users/test_signup.py
@@ -82,26 +82,6 @@ def test_signup_user_without_captcha(client):
 
 @override_settings()
 @pytest.mark.django_db
-def test_signup_user_when_captcha_is_none(client):
-    settings.CAPTCHA_URL = None
-    resp = client.post(
-        reverse("account_signup"),
-        {
-            "username": "dauser",
-            "email": "mail@example.com",
-            "get_newsletters": "on",
-            "password1": "password",
-            "password2": "password",
-            "terms_of_use": "on",
-        },
-    )
-    assert resp.status_code == 302
-    user = User.objects.get()
-    assert user.get_newsletters
-
-
-@override_settings()
-@pytest.mark.django_db
 def test_signup_user_when_not_captcha(client):
     settings.CAPTCHA_URL = ""
     resp = client.post(

--- a/tests/users/test_signup.py
+++ b/tests/users/test_signup.py
@@ -1,4 +1,6 @@
 import pytest
+from django.conf import settings
+from django.test import override_settings
 from django.urls import reverse
 
 from apps.users.models import User
@@ -56,3 +58,43 @@ def test_signup_user_unchecked_terms_of_use(client):
     assert User.objects.count() == 0
     assert not resp.context["form"].is_valid()
     assert list(resp.context["form"].errors.keys()) == ["terms_of_use"]
+
+
+@override_settings()
+@pytest.mark.django_db
+def test_signup_user_without_captcha(client):
+    del settings.CAPTCHA_URL
+    resp = client.post(
+        reverse("account_signup"),
+        {
+            "username": "dauser",
+            "email": "mail@example.com",
+            "get_newsletters": "on",
+            "password1": "password",
+            "password2": "password",
+            "terms_of_use": "on",
+        },
+    )
+    assert resp.status_code == 302
+    user = User.objects.get()
+    assert user.get_newsletters
+
+
+@override_settings()
+@pytest.mark.django_db
+def test_signup_user_when_captcha_is_none(client):
+    settings.CAPTCHA_URL = None
+    resp = client.post(
+        reverse("account_signup"),
+        {
+            "username": "dauser",
+            "email": "mail@example.com",
+            "get_newsletters": "on",
+            "password1": "password",
+            "password2": "password",
+            "terms_of_use": "on",
+        },
+    )
+    assert resp.status_code == 302
+    user = User.objects.get()
+    assert user.get_newsletters


### PR DESCRIPTION
This PR fixes the error:
```
AttributeError at /accounts/signup/

'Settings' object has no attribute 'CAPTCHA_URL'
```
when no captcha is installed in the project and thus no CAPTCHA_URL in the settings.

https://github.com/liqd/adhocracy-plus/issues/2064