### PR TITLE
[7428] templates/module_detail: pass initial_slide in link back to project

### DIFF
--- a/adhocracy-plus/templates/a4modules/module_detail.html
+++ b/adhocracy-plus/templates/a4modules/module_detail.html
@@ -100,7 +100,7 @@
                 <nav class="breadcrumbs u-spacer-bottom-double" aria-label="{% translate 'breadcrumbs' %}">
                     <ul>
                         <li>
-                            <a href="{{ project.get_absolute_url }}">
+                            <a href="{{ project.get_absolute_url }}?initialSlide={{ initial_slide }}">
                                 <i class="fa fa-arrow-left" aria-hidden="true"></i>
                                 {{ project.name }}
                             </a>

--- a/changelog/7428.md
+++ b/changelog/7428.md
@@ -1,0 +1,3 @@
+### Added
+
+- pass initial_slide as url param when going back from module to project


### PR DESCRIPTION
This needs https://github.com/liqd/adhocracy4/pull/1443

@m4ra @hklarnerliqd if you want to test it, you can checkout locally the a4 pull request and link it to your local adhocracy plus, like described here: https://github.com/liqd/adhocracy4/blob/main/docs/development.md#development-setup