### PR TITLE
refactors apps/debate and renames image fixtures

### DIFF
--- a/apps/debate/models.py
+++ b/apps/debate/models.py
@@ -73,14 +73,21 @@ class Subject(module_models.Item):
 
     @cached_property
     def last_three_creators(self):
-        comments = self.comments.all().select_related("creator").order_by("-created")
+        comments = (
+            self.comments.filter(
+                is_censored=False,
+                is_removed=False,
+            )
+            .select_related("creator")
+            .order_by("-created")
+        )
+
         last_three_creators = []
         if comments:
             for comment in comments:
-                if comment.creator not in last_three_creators and not (
-                    comment.is_censored or comment.is_removed
-                ):
+                if comment.creator not in last_three_creators:
                     last_three_creators.append(comment.creator)
                 if len(last_three_creators) >= 3:
-                    return last_three_creators
+                    break
+
         return last_three_creators

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,22 +46,22 @@ def apiclient():
 
 
 @pytest.fixture
-def ImagePNG():
+def image_png():
     return factory.django.ImageField(width=1500, height=1400, format="PNG")
 
 
 @pytest.fixture
-def ImageBMP():
+def image_bmp():
     return factory.django.ImageField(width=1500, height=1400, format="BMP")
 
 
 @pytest.fixture
-def smallImage():
+def small_image():
     return factory.django.ImageField(width=200, height=200)
 
 
 @pytest.fixture
-def bigImage():
+def big_image():
     return factory.django.ImageField(width=1500, height=1400)
 
 

--- a/tests/contrib/test_mixins.py
+++ b/tests/contrib/test_mixins.py
@@ -16,13 +16,13 @@ class IdeaForm(ImageRightOfUseMixin, forms.ModelForm):
 
 
 @pytest.mark.django_db
-def test_add_default(module, idea_factory, ImagePNG):
+def test_add_default(module, idea_factory, image_png):
     idea_no_image = idea_factory()
     form = IdeaForm(module=module, instance=idea_no_image)
     assert "right_of_use" in form.fields
     assert "right_of_use" not in form.initial
 
-    idea_with_image = idea_factory(image=ImagePNG)
+    idea_with_image = idea_factory(image=image_png)
     form = IdeaForm(module=module, instance=idea_with_image)
     assert "right_of_use" in form.fields
     assert "right_of_use" in form.initial
@@ -30,8 +30,8 @@ def test_add_default(module, idea_factory, ImagePNG):
 
 
 @pytest.mark.django_db
-def test_clean(module, idea_factory, ImagePNG):
-    idea_with_image = idea_factory(image=ImagePNG)
+def test_clean(module, idea_factory, image_png):
+    idea_with_image = idea_factory(image=image_png)
     data = {
         "right_of_use": False,
     }

--- a/tests/ideas/test_idea_api.py
+++ b/tests/ideas/test_idea_api.py
@@ -251,7 +251,7 @@ def test_user_cannot_update_idea_after_phase(apiclient, phase_factory, idea_fact
 
 @pytest.mark.django_db
 def test_user_can_add_and_delete_idea_image_during_phase(
-    apiclient, bigImage, phase_factory, idea_factory
+    apiclient, big_image, phase_factory, idea_factory
 ):
     phase, _, project, idea = setup_phase(
         phase_factory, idea_factory, phases.CollectPhase

--- a/tests/ideas/test_idea_models.py
+++ b/tests/ideas/test_idea_models.py
@@ -40,8 +40,8 @@ def test_project(idea):
 
 
 @pytest.mark.django_db
-def test_delete_idea(idea_factory, comment_factory, rating_factory, ImagePNG):
-    idea = idea_factory(image=ImagePNG)
+def test_delete_idea(idea_factory, comment_factory, rating_factory, image_png):
+    idea = idea_factory(image=image_png)
     image_path = os.path.join(settings.MEDIA_ROOT, idea.image.path)
     thumbnail_path = create_thumbnail(idea.image)
 
@@ -72,8 +72,8 @@ def test_delete_idea(idea_factory, comment_factory, rating_factory, ImagePNG):
 
 
 @pytest.mark.django_db
-def test_image_deleted_after_update(idea_factory, ImagePNG):
-    idea = idea_factory(image=ImagePNG)
+def test_image_deleted_after_update(idea_factory, image_png):
+    idea = idea_factory(image=image_png)
     image_path = os.path.join(settings.MEDIA_ROOT, idea.image.path)
     thumbnail_path = create_thumbnail(idea.image)
 

--- a/tests/organisations/test_organisation_models.py
+++ b/tests/organisations/test_organisation_models.py
@@ -23,44 +23,44 @@ def test_string_representation(organisation):
 
 
 @pytest.mark.django_db
-def test_image_validation_image_too_small(organisation_factory, smallImage):
-    organisation = organisation_factory(image=smallImage, logo=smallImage)
+def test_image_validation_image_too_small(organisation_factory, small_image):
+    organisation = organisation_factory(image=small_image, logo=small_image)
     with pytest.raises(Exception) as e:
         organisation.full_clean()
     assert "Image must be at least 500 pixels high" in str(e.value)
 
 
 @pytest.mark.django_db
-def test_image_big_enough(organisation_factory, bigImage, smallImage):
-    organisation = organisation_factory(image=bigImage, logo=smallImage)
+def test_image_big_enough(organisation_factory, big_image, small_image):
+    organisation = organisation_factory(image=big_image, logo=small_image)
     assert organisation.full_clean() is None
 
 
 @pytest.mark.django_db
-def test_image_validation_logo_too_big(organisation_factory, bigImage):
-    organisation = organisation_factory(logo=bigImage)
+def test_image_validation_logo_too_big(organisation_factory, big_image):
+    organisation = organisation_factory(logo=big_image)
     with pytest.raises(Exception) as e:
         organisation.full_clean()
     assert "Image must be at most 800 pixels high" in str(e.value)
 
 
 @pytest.mark.django_db
-def test_image_validation_type_not_allowed(organisation_factory, ImageBMP):
-    organisation = organisation_factory(image=ImageBMP, logo=ImageBMP)
+def test_image_validation_type_not_allowed(organisation_factory, image_bmp):
+    organisation = organisation_factory(image=image_bmp, logo=image_bmp)
     with pytest.raises(Exception) as e:
         organisation.full_clean()
     assert "Unsupported file format." in str(e.value)
 
 
 @pytest.mark.django_db
-def test_image_validation_image_type_allowed(organisation_factory, ImagePNG):
-    organisation = organisation_factory(image=ImagePNG)
+def test_image_validation_image_type_allowed(organisation_factory, image_png):
+    organisation = organisation_factory(image=image_png)
     assert organisation.full_clean() is None
 
 
 @pytest.mark.django_db
-def test_delete_organisation(organisation_factory, ImagePNG):
-    organisation = organisation_factory(image=ImagePNG, logo=ImagePNG)
+def test_delete_organisation(organisation_factory, image_png):
+    organisation = organisation_factory(image=image_png, logo=image_png)
     image_path = os.path.join(settings.MEDIA_ROOT, organisation.image.path)
     logo_path = os.path.join(settings.MEDIA_ROOT, organisation.logo.path)
     thumbnail_image_path = create_thumbnail(organisation.image)
@@ -83,8 +83,8 @@ def test_delete_organisation(organisation_factory, ImagePNG):
 
 
 @pytest.mark.django_db
-def test_image_deleted_after_update(organisation_factory, ImagePNG):
-    organisation = organisation_factory(image=ImagePNG, logo=ImagePNG)
+def test_image_deleted_after_update(organisation_factory, image_png):
+    organisation = organisation_factory(image=image_png, logo=image_png)
     image_path = os.path.join(settings.MEDIA_ROOT, organisation.image.path)
     logo_path = os.path.join(settings.MEDIA_ROOT, organisation.logo.path)
     thumbnail_image_path = create_thumbnail(organisation.image)

--- a/tests/projects/test_serializers.py
+++ b/tests/projects/test_serializers.py
@@ -13,11 +13,11 @@ def test_project_serializer(
     client,
     project_factory,
     phase_factory,
-    ImagePNG,
+    image_png,
 ):
     project_active = project_factory(
         name="active",
-        image=ImagePNG,
+        image=image_png,
         image_copyright="copyright",
         image_alt_text="img_alt",
     )
@@ -25,7 +25,7 @@ def test_project_serializer(
     project_active_and_future = project_factory(name="active and future")
     project_past = project_factory(
         name="past",
-        tile_image=ImagePNG,
+        tile_image=image_png,
         tile_image_copyright="copyright",
         tile_image_alt_text="img_alt",
     )

--- a/tests/topicprio/test_topic_models.py
+++ b/tests/topicprio/test_topic_models.py
@@ -46,8 +46,8 @@ def test_reference_number(topic):
 
 
 @pytest.mark.django_db
-def test_delete_idea(topic_factory, comment_factory, rating_factory, ImagePNG):
-    idea = topic_factory(image=ImagePNG)
+def test_delete_idea(topic_factory, comment_factory, rating_factory, image_png):
+    idea = topic_factory(image=image_png)
     image_path = os.path.join(settings.MEDIA_ROOT, idea.image.path)
     thumbnail_path = create_thumbnail(idea.image)
 
@@ -77,8 +77,8 @@ def test_delete_idea(topic_factory, comment_factory, rating_factory, ImagePNG):
 
 
 @pytest.mark.django_db
-def test_image_deleted_after_update(topic_factory, ImagePNG):
-    idea = topic_factory(image=ImagePNG)
+def test_image_deleted_after_update(topic_factory, image_png):
+    idea = topic_factory(image=image_png)
     image_path = os.path.join(settings.MEDIA_ROOT, idea.image.path)
     thumbnail_path = create_thumbnail(idea.image)
 

--- a/tests/users/test_models.py
+++ b/tests/users/test_models.py
@@ -7,8 +7,8 @@ from adhocracy4.test.helpers import create_thumbnail
 
 
 @pytest.mark.django_db
-def test_delete_user_signal(user_factory, ImagePNG):
-    user = user_factory(_avatar=ImagePNG)
+def test_delete_user_signal(user_factory, image_png):
+    user = user_factory(_avatar=image_png)
     image_path = os.path.join(settings.MEDIA_ROOT, user._avatar.path)
 
     assert os.path.isfile(image_path)
@@ -18,8 +18,8 @@ def test_delete_user_signal(user_factory, ImagePNG):
 
 
 @pytest.mark.django_db
-def test_image_deleted_after_update(user_factory, ImagePNG):
-    user = user_factory(_avatar=ImagePNG)
+def test_image_deleted_after_update(user_factory, image_png):
+    user = user_factory(_avatar=image_png)
     image_path = os.path.join(settings.MEDIA_ROOT, user._avatar.path)
     thumbnail_path = create_thumbnail(user._avatar)
 


### PR DESCRIPTION
The intention of this refactor is to
- rename the image fixtures to adhere to Python naming conventions (camel case)
- simplify the property `last_three_creators` by filtering the query directly