### PR TITLE
forms shouldn't use browser validation but our own error messages.

### DIFF
--- a/adhocracy-plus/templates/a4dashboard/base_form_project.html
+++ b/adhocracy-plus/templates/a4dashboard/base_form_project.html
@@ -14,7 +14,7 @@
         <span>{{ error }}</span>
     {% endfor %}
 
-    <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
+    <form novalidate enctype="multipart/form-data" action="{{ request.path }}" method="post">
         {% csrf_token %}
 
         {% include view.form_template_name %}

--- a/apps/budgeting/templates/a4_candy_budgeting/includes/proposal_form.html
+++ b/apps/budgeting/templates/a4_candy_budgeting/includes/proposal_form.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<form enctype="multipart/form-data" action="{{ request.path }}" method="post">
+<form novalidate enctype="multipart/form-data" action="{{ request.path }}" method="post">
     {% csrf_token %}
     {{ form.media }}
 

--- a/apps/ideas/templates/a4_candy_ideas/idea_moderate_form.html
+++ b/apps/ideas/templates/a4_candy_ideas/idea_moderate_form.html
@@ -29,7 +29,7 @@
                 </nav>
 
                 <h1>{% translate 'Feedback on this idea' %}</h1>
-                <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
+                <form novalidate enctype="multipart/form-data" action="{{ request.path }}" method="post">
                     {% csrf_token %}
                     {% for form in forms.values %}
                         {{ form.media }}

--- a/apps/ideas/templates/a4_candy_ideas/includes/idea_form.html
+++ b/apps/ideas/templates/a4_candy_ideas/includes/idea_form.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<form enctype="multipart/form-data" action="{{ request.path }}" method="post">
+<form novalidate enctype="multipart/form-data" action="{{ request.path }}" method="post">
     {% csrf_token %}
     {{ form.media }}
 

--- a/apps/interactiveevents/templates/a4_candy_interactive_events/extrafields_dashboard_form.html
+++ b/apps/interactiveevents/templates/a4_candy_interactive_events/extrafields_dashboard_form.html
@@ -9,7 +9,7 @@
     {% endfor %}
 
 
-    <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
+    <form novalidate enctype="multipart/form-data" action="{{ request.path }}" method="post">
         {% csrf_token %}
 
         {% include 'a4_candy_contrib/includes/form_field.html' with field=form.live_stream %}

--- a/apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_form.html
+++ b/apps/mapideas/templates/a4_candy_mapideas/includes/mapidea_form.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<form enctype="multipart/form-data" action="{{ request.path }}" method="post">
+<form novalidate enctype="multipart/form-data" action="{{ request.path }}" method="post">
     {% csrf_token %}
     {{ form.media }}
 

--- a/apps/mapideas/templates/a4_candy_mapideas/mapidea_moderate_form.html
+++ b/apps/mapideas/templates/a4_candy_mapideas/mapidea_moderate_form.html
@@ -28,7 +28,7 @@
                 </nav>
 
                 <h1>{% translate 'Moderate idea' %}</h1>
-                <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
+                <form novalidate enctype="multipart/form-data" action="{{ request.path }}" method="post">
                     {% csrf_token %}
                     {% for form in forms.values %}
                         {{ form.media }}

--- a/apps/newsletters/templates/a4_candy_newsletters/restricted_newsletter_dashboard_form.html
+++ b/apps/newsletters/templates/a4_candy_newsletters/restricted_newsletter_dashboard_form.html
@@ -7,7 +7,7 @@
 <div class="col-md-9">
     <h1 class="u-first-heading">{% translate "Create Newsletter" %}</h1>
 
-    <form enctype="multipart/form-data" action="{{ request.path }}" method="post">
+    <form novalidate enctype="multipart/form-data" action="{{ request.path }}" method="post">
         {% csrf_token %}
         {% include 'a4_candy_contrib/includes/form_field.html' with field=form.project %}
 

--- a/apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_form.html
+++ b/apps/offlineevents/templates/a4_candy_offlineevents/includes/offlineevent_form.html
@@ -1,5 +1,5 @@
 {% load i18n %}
-<form enctype="multipart/form-data" action="{{ request.path }}" method="post">
+<form novalidate enctype="multipart/form-data" action="{{ request.path }}" method="post">
     {% csrf_token %}
 
     {% include 'a4_candy_contrib/includes/form_field.html' with field=form.event_type %}

--- a/changelog/7632.md
+++ b/changelog/7632.md
@@ -21,4 +21,6 @@
 - update a4 to ckeditor5-transition-a4
 - add image validator which validates that all img tags have the alt attribute
   set to all ckedito5 fields
-
+- disable browser-side form checks for forms which use ckeditor by adding
+  `novalidate` to them  This is necessary as ckeditor form fields which are
+  required will block form submission otherwise.


### PR DESCRIPTION
see https://github.com/liqd/a4-meinberlin/commit/e1aecbae8fb529ae1bb8b58e1d761827a8a15485

fixes #2571

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
