### PR TITLE
[8104] apps/accounts: add option to delete account to user profile

### DIFF
--- a/adhocracy-plus/assets/scss/components/_account.scss
+++ b/adhocracy-plus/assets/scss/components/_account.scss
@@ -20,3 +20,15 @@
         margin-left: 2.5 * $spacer;
     }
 }
+
+.account__delete-modal {
+    .cancel-button {
+        @extend .btn;
+        @extend .btn--default;
+    }
+
+    .submit-button {
+        @extend .btn;
+        @extend .btn--danger;
+    }
+}

--- a/adhocracy-plus/templates/email_base.subject
+++ b/adhocracy-plus/templates/email_base.subject
@@ -1,1 +1,3 @@
+{% load i18n wagtailsettings_tags %}
+{% get_settings use_default_site=True %}
 {% block subject %}{% endblock %}

--- a/adhocracy-plus/templates/email_base.txt
+++ b/adhocracy-plus/templates/email_base.txt
@@ -1,4 +1,6 @@
 {% load i18n wagtailsettings_tags %}
+{% get_settings use_default_site=True %}
+
 {% block headline %}{% endblock %}
 {% block sub-headline %}{% endblock %}
 

--- a/apps/account/emails.py
+++ b/apps/account/emails.py
@@ -1,0 +1,8 @@
+from apps.users.emails import EmailAplus as Email
+
+
+class AccountDeletionEmail(Email):
+    template_name = "a4_candy_account/emails/account_deleted"
+
+    def get_receivers(self):
+        return [self.object.email]

--- a/apps/account/forms.py
+++ b/apps/account/forms.py
@@ -45,6 +45,10 @@ class ProfileForm(forms.ModelForm):
         return username
 
 
+class AccountDeletionForm(forms.Form):
+    password = forms.CharField(widget=forms.PasswordInput())
+
+
 class OrganisationTermsOfUseForm(forms.ModelForm):
     class Meta:
         model = OrganisationTermsOfUse

--- a/apps/account/forms.py
+++ b/apps/account/forms.py
@@ -46,7 +46,11 @@ class ProfileForm(forms.ModelForm):
 
 
 class AccountDeletionForm(forms.Form):
-    password = forms.CharField(widget=forms.PasswordInput())
+    password = forms.CharField(
+        label=_("Password"),
+        strip=False,
+        widget=forms.PasswordInput(attrs={"autocomplete": "new-password"}),
+    )
 
 
 class OrganisationTermsOfUseForm(forms.ModelForm):

--- a/apps/account/templates/a4_candy_account/account_dashboard.html
+++ b/apps/account/templates/a4_candy_account/account_dashboard.html
@@ -50,6 +50,13 @@
                             {% translate 'User Agreements' %}
                         </a>
                     </li>
+                    <li class="dashboard-nav__page">
+                        <a href="{% url 'account_deletion' %}"
+                           class="dashboard-nav__item dashboard-nav__item--interactive {% if request.resolver_match.url_name == "account_deletion" %}is-active{% endif %}">
+                            <i class="fas fa-user-slash" aria-hidden="true"></i>
+                            {% translate 'Delete account' %}
+                        </a>
+                    </li>
                 </ul>
             {% endwith %}
             </div>

--- a/apps/account/templates/a4_candy_account/account_deletion.html
+++ b/apps/account/templates/a4_candy_account/account_deletion.html
@@ -18,6 +18,8 @@
             {% for field in form %}
                 {% include 'a4_candy_contrib/includes/form_field.html' with field=field %}
             {% endfor %}
+            {# prevent form submission via enter/return, effectively bypassing the modal #}
+            <button class="d-none" type="submit" disabled aria-hidden="true"></button>
         </form>
         <div class="d-flex justify-content-end">
             <button class="btn btn--primary" data-bs-toggle="modal" data-bs-target="#account-delete-modal">Delete account</button>

--- a/apps/account/templates/a4_candy_account/account_deletion.html
+++ b/apps/account/templates/a4_candy_account/account_deletion.html
@@ -2,44 +2,51 @@
 
 {% load i18n %}
 
-{% block title %}{% translate 'Your user profile' %} &mdash; {{ block.super }}{% endblock %}
+{% block title %}
+    {% translate 'Your user profile' %}
+    &mdash;
+    {{ block.super }}
+{% endblock %}
 {% block dashboard_content %}
-    <h1 class="mt-0">{% translate 'Delete account' %}</h1>
-    <p class="u-text--gray">{% blocktranslate %}Please note that deleting your account will result in the permanent removal of all associated data and content, including your comments, ideas & votes.{% endblocktranslate %}</p>
-    <p class="u-text--gray">{% blocktranslate %} To confirm your identity, please enter your password to proceed.{% endblocktranslate %}</p>
-    <form id="account-delete-form" novalidate action="{% url "account_deletion" %}" method="post">
-        {% csrf_token %}
-        {% for field in form %}
-            {% include 'a4_candy_contrib/includes/form_field.html' with field=field %}
-        {% endfor %}
+    <div class="my-5 my-md-0">
+        <h1 class="mt-0">{% translate 'Delete account' %}</h1>
+        <p class="u-text--gray">{% blocktranslate %}Please note that deleting your account will result in the permanent removal of all associated data and content, including your comments, ideas & votes.{% endblocktranslate %}</p>
+        <p class="u-text--gray">{% blocktranslate %}
+            To confirm your identity, please enter your password to proceed:{% endblocktranslate %}</p>
+        <form id="account-delete-form" novalidate action="{% url "account_deletion" %}" method="post">
+            {% csrf_token %}
+            {% for field in form %}
+                {% include 'a4_candy_contrib/includes/form_field.html' with field=field %}
+            {% endfor %}
+        </form>
+        <div class="d-flex justify-content-end">
+            <button class="btn btn--primary" data-bs-toggle="modal" data-bs-target="#account-delete-modal">Delete account</button>
+        </div>
+    </div>
 
-    </form>
-    <button class="btn btn--primary" data-bs-toggle="modal" data-bs-target="#account-delete-modal">Delete account</button>
     <div class="modal fade account__delete-modal" id="account-delete-modal" tabindex="-1" role="dialog" aria-hidden="true">
-    <div
-        class="modal-dialog modal-dialog-centered"
-        role="document"
-    >
-        <div class="modal-content">
-            <div class="modal-header">
-                <!-- Not using Bootstrap, but utility classes on purpose to align with component in A4 -->
-                <h2 className="u-no-margin-bottom u-spacer-top-one-half">
-                    {% translate 'Delete account' %}
-                </h2>
-                <button class="close" data-bs-dismiss="modal" aria-label="Close">
-                    <i class="fa fa-times"></i>
-                </button>
-            </div>
-            <div class="modal-body">
-                <div class="u-spacer-bottom u-text--gray">
-                    {% blocktranslate %}Are you sure you want to delete your account?{% endblocktranslate %}
+        <div class="modal-dialog modal-dialog-centered" role="document">
+            <div class="modal-content p-3">
+                <div
+                    class="modal-header">
+                    <!-- Not using Bootstrap, but utility classes on purpose to align with component in A4 -->
+                    <h2 className="u-no-margin-bottom u-spacer-top-one-half">
+                        {% translate 'Delete account' %}
+                    </h2>
+                    <button class="close" data-bs-dismiss="modal" aria-label="Close">
+                        <i class="fa fa-times"></i>
+                    </button>
                 </div>
-            </div>
-            <div class="modal-footer">
-                    <button type="button" class="cancel-button" data-bs-dismiss="modal">{% translate 'cancel' %}</button>
+                <div class="modal-body">
+                    <div class="u-spacer-bottom u-text--gray">
+                        {% blocktranslate %}Are you sure you want to delete your account?{% endblocktranslate %}
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="cancel-button" data-bs-dismiss="modal">{% translate 'Cancel' %}</button>
                     <button type="submit" form="account-delete-form" class="submit-button">{% translate 'Delete Account' %}</button>
+                </div>
             </div>
         </div>
     </div>
-</div>
 {% endblock dashboard_content %}

--- a/apps/account/templates/a4_candy_account/account_deletion.html
+++ b/apps/account/templates/a4_candy_account/account_deletion.html
@@ -1,0 +1,45 @@
+{% extends "a4_candy_account/account_dashboard.html" %}
+
+{% load i18n %}
+
+{% block title %}{% translate 'Your user profile' %} &mdash; {{ block.super }}{% endblock %}
+{% block dashboard_content %}
+    <h1 class="mt-0">{% translate 'Delete account' %}</h1>
+    <p class="u-text--gray">{% blocktranslate %}Please note that deleting your account will result in the permanent removal of all associated data and content, including your comments, ideas & votes.{% endblocktranslate %}</p>
+    <p class="u-text--gray">{% blocktranslate %} To confirm your identity, please enter your password to proceed.{% endblocktranslate %}</p>
+    <form id="account-delete-form" novalidate action="{% url "account_deletion" %}" method="post">
+        {% csrf_token %}
+        {% for field in form %}
+            {% include 'a4_candy_contrib/includes/form_field.html' with field=field %}
+        {% endfor %}
+
+    </form>
+    <button class="btn btn--primary" data-bs-toggle="modal" data-bs-target="#account-delete-modal">Delete account</button>
+    <div class="modal fade account__delete-modal" id="account-delete-modal" tabindex="-1" role="dialog" aria-hidden="true">
+    <div
+        class="modal-dialog modal-dialog-centered"
+        role="document"
+    >
+        <div class="modal-content">
+            <div class="modal-header">
+                <!-- Not using Bootstrap, but utility classes on purpose to align with component in A4 -->
+                <h2 className="u-no-margin-bottom u-spacer-top-one-half">
+                    {% translate 'Delete account' %}
+                </h2>
+                <button class="close" data-bs-dismiss="modal" aria-label="Close">
+                    <i class="fa fa-times"></i>
+                </button>
+            </div>
+            <div class="modal-body">
+                <div class="u-spacer-bottom u-text--gray">
+                    {% blocktranslate %}Are you sure you want to delete your account?{% endblocktranslate %}
+                </div>
+            </div>
+            <div class="modal-footer">
+                    <button type="button" class="cancel-button" data-bs-dismiss="modal">{% translate 'cancel' %}</button>
+                    <button type="submit" form="account-delete-form" class="submit-button">{% translate 'Delete Account' %}</button>
+            </div>
+        </div>
+    </div>
+</div>
+{% endblock dashboard_content %}

--- a/apps/account/templates/a4_candy_account/emails/account_deleted.en.email
+++ b/apps/account/templates/a4_candy_account/emails/account_deleted.en.email
@@ -1,0 +1,39 @@
+{% extends 'email_base.'|add:part_type %}
+{% load i18n wagtailsettings_tags %}
+{% get_settings use_default_site=True %}
+
+{% block subject %}{% blocktranslate with platformname=settings.a4_candy_cms_settings.OrganisationSettings.platform_name %}Confirmation: Deletion of Your Account on {{ platformname }}{% endblocktranslate %}{% endblock %}
+{% block headline %}{% blocktranslate with platformname=settings.a4_candy_cms_settings.OrganisationSettings.platform_name %}Your account on {{ platformname }} has been deleted{% endblocktranslate %}{% endblock %}
+
+{% block content %}
+{% if part_type == "txt" %}
+We would like to confirm that your account has been successfully deleted from our platform. We regret that you have chosen to leave us but we respect your decision.
+
+Please note that all data associated with your account, including your personal information and activities, have been permanently deleted. You will not receive any further communications from us unless you decide to re-register at a later date.
+
+We thank you for your past use of our services and remain available to assist you with any questions or concerns.
+
+Best regards,
+
+adhocracy+ Team
+{% else %}
+<p>
+We would like to confirm that your account has been successfully deleted from our platform. We regret that you have chosen to leave us but we respect your decision.
+</p>
+<p>
+Please note that all data associated with your account, including your personal information and activities, have been permanently deleted. You will not receive any further communications from us unless you decide to re-register at a later date.
+</p>
+<p>
+We thank you for your past use of our services and remain available to assist you with any questions or concerns.
+</p>
+<p>
+Best regards,
+</p>
+
+<p>
+adhocracy+ Team
+</p>
+{% endif %}
+{% endblock %}
+
+{% block reason %}{% blocktranslate %}This email was sent to {{ receiver }}. If you have any further questions, please contact us via {{ contact_email }}{% endblocktranslate %}{% endblock %}

--- a/apps/account/urls.py
+++ b/apps/account/urls.py
@@ -6,6 +6,11 @@ urlpatterns = [
     path("", views.AccountView.as_view(), name="account"),
     path("profile/", views.ProfileUpdateView.as_view(), name="account_profile"),
     path(
+        "account_deletion/",
+        views.AccountDeletionView.as_view(),
+        name="account_deletion",
+    ),
+    path(
         "agreements/",
         views.OrganisationTermsOfUseUpdateView.as_view(),
         name="user_agreements",

--- a/apps/account/views.py
+++ b/apps/account/views.py
@@ -13,6 +13,7 @@ from apps.users.models import User
 from apps.users.utils import set_session_language
 
 from . import forms
+from .emails import AccountDeletionEmail
 
 
 class AccountView(RedirectView):
@@ -62,6 +63,7 @@ class AccountDeletionView(LoginRequiredMixin, SuccessMessageMixin, generic.Delet
             )
             return super().form_invalid(form)
         logout(self.request)
+        AccountDeletionEmail.send(user)
         return super().form_valid(form)
 
 

--- a/apps/account/views.py
+++ b/apps/account/views.py
@@ -1,6 +1,8 @@
 from django.conf import settings
+from django.contrib.auth import logout
 from django.contrib.auth.mixins import LoginRequiredMixin
 from django.contrib.messages.views import SuccessMessageMixin
+from django.core.exceptions import ValidationError
 from django.db import transaction
 from django.shortcuts import get_object_or_404
 from django.utils.translation import gettext_lazy as _
@@ -40,6 +42,27 @@ class ProfileUpdateView(LoginRequiredMixin, SuccessMessageMixin, generic.UpdateV
         response = super().render_to_response(context, **response_kwargs)
         response.set_cookie(settings.LANGUAGE_COOKIE_NAME, self.request.user.language)
         return response
+
+
+class AccountDeletionView(LoginRequiredMixin, SuccessMessageMixin, generic.DeleteView):
+    template_name = "a4_candy_account/account_deletion.html"
+    form_class = forms.AccountDeletionForm
+    success_message = _("Your account was successfully deleted.")
+    success_url = "/"
+
+    def get_object(self):
+        return get_object_or_404(User, pk=self.request.user.id)
+
+    def form_valid(self, form):
+        user = self.request.user
+        password = form.cleaned_data.get("password")
+        if not user.check_password(password):
+            form.add_error(
+                "password", ValidationError("Incorrect password.", "invalid")
+            )
+            return super().form_invalid(form)
+        logout(self.request)
+        return super().form_valid(form)
 
 
 class OrganisationTermsOfUseUpdateView(

--- a/apps/contrib/management/commands/send_test_emails.py
+++ b/apps/contrib/management/commands/send_test_emails.py
@@ -11,6 +11,7 @@ from adhocracy4.emails.mixins import SyncEmailMixin
 from adhocracy4.projects.models import Project
 from adhocracy4.reports import emails as reports_emails
 from adhocracy4.reports.models import Report
+from apps.account.emails import AccountDeletionEmail
 from apps.cms.contacts.models import CustomFormSubmission
 from apps.cms.contacts.models import FormPage
 from apps.ideas.models import Idea
@@ -85,6 +86,7 @@ class Command(BaseCommand):
 
         self._send_notification_blocked_comment()
         self._send_notification_moderator_comment_feedback()
+        self._send_account_deleted_mail()
 
     def _send_notifications_create_idea(self):
         # Send notification for a newly created item
@@ -397,4 +399,11 @@ class Command(BaseCommand):
             comment_url=feedback.comment.get_absolute_url(),
             receiver=[self.user],
             template_name=notification_emails.NotifyCreatorOnModeratorCommentFeedback.template_name,
+        )
+
+    def _send_account_deleted_mail(self):
+        TestEmail.send(
+            self.user,
+            receiver=[self.user],
+            template_name=AccountDeletionEmail.template_name,
         )

--- a/changelog/8104.md
+++ b/changelog/8104.md
@@ -1,0 +1,3 @@
+### Added
+
+- add option to delete account to user settings

--- a/tests/account/test_views.py
+++ b/tests/account/test_views.py
@@ -1,5 +1,6 @@
 import pytest
 from django.contrib.auth import get_user_model
+from django.core import mail
 from django.urls import reverse
 
 from adhocracy4.test.helpers import redirect_target
@@ -101,6 +102,7 @@ def test_account_deletion_invalid_password(client, user, password):
     assert response.status_code == 200
     assert User.objects.count() == 1
     assert User.objects.filter(pk=pk).exists()
+    assert len(mail.outbox) == 0
     form = response.context_data["form"]
     assert not form.is_valid()
 
@@ -124,5 +126,9 @@ def test_account_deletion(client, user):
     assert response.status_code == 302
     assert User.objects.count() == 0
     assert not User.objects.filter(pk=user.pk).exists()
+    assert len(mail.outbox) == 1
+    assert mail.outbox[0].subject == (
+        "Confirmation: Deletion of Your Account on " "adhocracy+"
+    )
     # assert that user is redirected to homepage
     assert redirect_target(response) == "wagtail_serve"

--- a/tests/account/test_views.py
+++ b/tests/account/test_views.py
@@ -1,4 +1,5 @@
 import pytest
+from django.contrib.auth import get_user_model
 from django.urls import reverse
 
 from adhocracy4.test.helpers import redirect_target
@@ -74,3 +75,54 @@ def test_organisation_terms_edit(
     assert not terms_1.has_agreed
     terms_2.refresh_from_db()
     assert terms_2.has_agreed
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("password", [None, "", "wrong_password"])
+def test_account_deletion_invalid_password(client, user, password):
+    User = get_user_model()
+    pk = user.pk
+    client.login(email=user.email, password="password")
+    url = reverse("account_deletion")
+
+    assert User.objects.count() == 1
+    assert User.objects.filter(pk=pk).exists()
+    if password is None:
+        # test without data
+        response = client.post(url)
+    else:
+        response = client.post(
+            url,
+            {
+                "password": password,
+            },
+        )
+
+    assert response.status_code == 200
+    assert User.objects.count() == 1
+    assert User.objects.filter(pk=pk).exists()
+    form = response.context_data["form"]
+    assert not form.is_valid()
+
+
+@pytest.mark.django_db
+def test_account_deletion(client, user):
+    User = get_user_model()
+    client.login(email=user.email, password="password")
+    url = reverse("account_deletion")
+
+    assert User.objects.count() == 1
+    assert User.objects.filter(pk=user.pk).exists()
+
+    response = client.post(
+        url,
+        {
+            "password": "password",
+        },
+    )
+
+    assert response.status_code == 302
+    assert User.objects.count() == 0
+    assert not User.objects.filter(pk=user.pk).exists()
+    # assert that user is redirected to homepage
+    assert redirect_target(response) == "wagtail_serve"


### PR DESCRIPTION
First attempt at adding the account deletion submenu

page: http://127.0.0.1:8004/account/account_deletion/

**Tasks**
- [x] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog
