### PR TITLE
userdashboard: fix padding and dropdown icon on userdashboard nav for

### DIFF
--- a/adhocracy-plus/assets/scss/components/_userdashboard.scss
+++ b/adhocracy-plus/assets/scss/components/_userdashboard.scss
@@ -53,6 +53,12 @@
     width: 100%;
     display: flex;
     justify-content: space-between;
+    padding-left: $spacer;
+    padding-right: $spacer;
+
+    i.fa-caret-down {
+        align-self: center;
+    }
 }
 
 .userdashboard-mod-feedback {

--- a/changelog/1842.md
+++ b/changelog/1842.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- fix padding on dashboard nav dropdown for mobile
+- fix dropdown caret icon not being cented on dashboard nav dropdown for mobile


### PR DESCRIPTION
mobile screens

fixes #1842

can be tested with small screen sizes here: http://127.0.0.1:8004/userdashboard/overview/

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog
