### PR TITLE
fix mixed language on profile page when changing prefered user language there

### DIFF
--- a/apps/account/views.py
+++ b/apps/account/views.py
@@ -37,6 +37,7 @@ class ProfileUpdateView(LoginRequiredMixin, SuccessMessageMixin, generic.UpdateV
         return super(ProfileUpdateView, self).form_valid(form)
 
     def render_to_response(self, context, **response_kwargs):
+        set_session_language(self.request.user.email, self.request.user.language)
         response = super().render_to_response(context, **response_kwargs)
         response.set_cookie(settings.LANGUAGE_COOKIE_NAME, self.request.user.language)
         return response


### PR DESCRIPTION
Testing: go to http://127.0.0.1:8004/account/profile/ and change the language, both alert and rest of the page should be in the new language

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
