### PR TITLE
fix dropdown on project detail

### DIFF
--- a/adhocracy-plus/assets/scss/components/_dropdown.scss
+++ b/adhocracy-plus/assets/scss/components/_dropdown.scss
@@ -29,6 +29,7 @@
         &:focus {
             text-decoration: none;
             background-color: $bg-tertiary;
+            color: $text-color;
         }
 
         i {

--- a/adhocracy-plus/assets/scss/components/_tabs.scss
+++ b/adhocracy-plus/assets/scss/components/_tabs.scss
@@ -10,6 +10,7 @@
     border-bottom: 2px solid $brand-primary;
     text-align: center;
     margin-bottom: $spacer * 2;
+    z-index: 3;
 }
 
 .tab {

--- a/apps/projects/templates/a4_candy_projects/project_detail.html
+++ b/apps/projects/templates/a4_candy_projects/project_detail.html
@@ -33,7 +33,7 @@
 {% endblock %}
 
 {% block extra_messages %}
-<div class="u-bg-light py-5">
+<div class="u-bg-light py-md-5">
     <div class="container">
         <div class="col-12 container--shadow">
             {{ block.super }}


### PR DESCRIPTION
Fixes #2506 
Adjusted tablist z-index to align with main section cards. 
Fixed text color on hover of active element

<img src="https://github.com/liqd/adhocracy-plus/assets/8156337/938ae86c-7455-4386-858c-327757d9a769" alt="Screenshot adhocracy _liqd-orga" style="max-width: 350px;">






