### PR TITLE
fx badge text overflowing/not breaking on long word or sentence

### DIFF
--- a/adhocracy-plus/assets/scss/components/_badge.scss
+++ b/adhocracy-plus/assets/scss/components/_badge.scss
@@ -6,6 +6,10 @@
     font-weight: normal;
     border-radius: 0.4em;
     padding: 0.2em 0.7em;
+    text-align: start;
+    white-space: normal;
+    word-break: normal;
+    overflow-wrap: anywhere;
 }
 
 .badge.badge--big {

--- a/changelog/2582.md
+++ b/changelog/2582.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- fix badge text overflowing/not breaking on long words or sentences


### PR DESCRIPTION
fixes #2582

testing: add a mapidea and add a long point label (at the bottom of the form)

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
