### PR TITLE
[8134] add anchor to timeline links so users always see the main content when

### DIFF
--- a/adhocracy-plus/templates/a4modules/module_detail.html
+++ b/adhocracy-plus/templates/a4modules/module_detail.html
@@ -100,7 +100,7 @@
                 <nav class="breadcrumbs u-spacer-bottom-double" aria-label="{% translate 'breadcrumbs' %}">
                     <ul>
                         <li>
-                            <a href="{{ project.get_absolute_url }}?initialSlide={{ initial_slide }}">
+                            <a href="{{ project.get_absolute_url }}?initialSlide={{ initial_slide }}#timeline-carousel">
                                 <i class="fa fa-arrow-left" aria-hidden="true"></i>
                                 {{ project.name }}
                             </a>

--- a/apps/documents/models.py
+++ b/apps/documents/models.py
@@ -34,7 +34,9 @@ class Chapter(module_models.Item):
             ),
         )
         if self.project.display_timeline and not self.module.is_in_module_cluster:
-            return "{}?initialSlide={}".format(url, self.module.get_timeline_index)
+            return "{}?initialSlide={}#timeline-carousel".format(
+                url, self.module.get_timeline_index
+            )
         return url
 
     @cached_property

--- a/apps/offlineevents/models.py
+++ b/apps/offlineevents/models.py
@@ -59,7 +59,7 @@ class OfflineEvent(UserGeneratedContentModel):
 
     def get_absolute_url(self):
         if self.project.display_timeline:
-            return "{}?initialSlide={}".format(
+            return "{}?initialSlide={}#timeline-carousel".format(
                 self.project.get_absolute_url(), self.get_timeline_index
             )
         return self.project.get_absolute_url()

--- a/apps/projects/templates/a4_candy_projects/includes/project_timeline-carousel.html
+++ b/apps/projects/templates/a4_candy_projects/includes/project_timeline-carousel.html
@@ -5,7 +5,7 @@
         <div id="timeline-carousel" data-initial-slide="{{ initial_slide }}">
             <div class="timeline-carousel__item">
                 {% for date in dates %}
-                    <a href="{{ project.get_absolute_url }}?initialSlide={{ forloop.counter0 }}"
+                    <a href="{{ project.get_absolute_url }}?initialSlide={{ forloop.counter0 }}#timeline-carousel"
                        aria-labelledby="timeline_item timeline_entry_{{ forloop.counter }}">
                         <div id="timeline_item"
                              class="timeline-carousel__dot {% if forloop.counter0 == initial_slide %} initial {% endif %}">

--- a/changelog/8134.md
+++ b/changelog/8134.md
@@ -1,0 +1,4 @@
+### Changed
+
+- add anchor to all timeline buttons / links to make the browser always show the
+  main content


### PR DESCRIPTION
switching between modules or using the breadcrumbs.

Testing: add a project with multiple modules with different start phases / dates. Check that timeline buttons include the anchor and jump to timeline / content

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
