### PR TITLE
apps/users: disable help text for password field on login page

### DIFF
--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -31,6 +31,7 @@ class DefaultLoginForm(LoginForm):
         self.fields["login"].label = _("Username/e-mail")
         del self.fields["login"].widget.attrs["placeholder"]
         del self.fields["password"].widget.attrs["placeholder"]
+        self.fields["password"].help_text = ""
         self.fields["login"].widget.attrs["autocomplete"] = "username"
         self.fields["password"].widget.attrs["autocomplete"] = "current-password"
 

--- a/changelog/_1113.md
+++ b/changelog/_1113.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- disable password help text provided by django-allauth on login form


### PR DESCRIPTION
**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog
