### PR TITLE
assets/js: add polyfill for Object.hasOwn() to make comments work on

### DIFF
--- a/adhocracy-plus/assets/js/app.js
+++ b/adhocracy-plus/assets/js/app.js
@@ -3,6 +3,8 @@ import 'django'
 import 'select2' // used to skin select element used in livequestions
 import 'slick-carousel' // for project timeline
 
+import 'core-js/actual/object/has-own' // required polyfill for older browsers
+
 import '../../../apps/actions/assets/timestamps.js'
 import '../../../apps/dashboard/assets/ajax_modal.js'
 import '../../../apps/maps/assets/map-address.js'

--- a/changelog/2735.md
+++ b/changelog/2735.md
@@ -1,0 +1,4 @@
+### Fixed
+
+- added poyfill for Object.hasOwn() to make comments work on older browsers
+  (e.g. safari 14) (#2735)

--- a/package.json
+++ b/package.json
@@ -64,6 +64,7 @@
     "@testing-library/react": "15.0.7",
     "babel-loader": "9.1.3",
     "copy-webpack-plugin": "12.0.2",
+    "core-js": "3.38.0",
     "eslint": "8.41.0",
     "eslint-config-standard": "17.0.0",
     "eslint-config-standard-jsx": "11.0.0",


### PR DESCRIPTION
older browsers

fixes #2735

Testing: Test on older browsers (e.g. safari 14)

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
