### PR TITLE
apps/organisations: change sorting for past projects

### DIFF
--- a/apps/organisations/models.py
+++ b/apps/organisations/models.py
@@ -213,7 +213,7 @@ class Organisation(TranslatableModel):
             projects.annotate(project_start=min_module_start)
             .annotate(project_end=max_module_end)
             .filter(project_end__lt=now)
-            .order_by("project_start")
+            .order_by("-project_end")
         )
 
         return sorted_active_projects, sorted_future_projects, sorted_past_projects

--- a/changelog/8325.md
+++ b/changelog/8325.md
@@ -1,0 +1,4 @@
+### Changed
+
+- change sorting of past projects on organisation detail page from oldest ->
+  newest to newest -> oldest (end date).


### PR DESCRIPTION
apps/organisations: change sorting for past projects from oldest -> newst to newest -> oldest (end date).

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [x] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog
