### PR TITLE
fix comment image spacing

### DIFF
--- a/adhocracy-plus/assets/scss/components/_a4-comments.scss
+++ b/adhocracy-plus/assets/scss/components/_a4-comments.scss
@@ -99,6 +99,10 @@
 
 }
 
+.a4-comments__user-img {
+    width: 3.75 * $spacer;
+}
+
 .a4-comments__dropdown {
     text-align: right;
 

--- a/changelog/_5666.md
+++ b/changelog/_5666.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- fixed wrong spacing between user image and user name in comments (#2752)


### PR DESCRIPTION
Fix comment image spacing on the screen size. Not sure if that's the best solution so more of a proposal, feel free to close / rework this!

fixes #2752

depends on #2747 

testing: any module with comments

before: 
![Screenshot 2024-08-22 at 10-01-47 dasda — adhocracy _liqd-orga](https://github.com/user-attachments/assets/66fc0b18-3f0a-4793-ab91-f2e9367f518a)

after:
![Screenshot 2024-08-22 at 10-00-50 dasda — adhocracy _liqd-orga](https://github.com/user-attachments/assets/57274bd5-6ead-494b-8402-a0d778941a5e)


**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
