### PR TITLE
Revert "assets/js: add polyfill for Object.hasOwn() to make comments …

### DIFF
--- a/adhocracy-plus/assets/js/app.js
+++ b/adhocracy-plus/assets/js/app.js
@@ -3,8 +3,6 @@ import 'django'
 import 'select2' // used to skin select element used in livequestions
 import 'slick-carousel' // for project timeline
 
-import 'core-js/actual/object/has-own' // required polyfill for older browsers
-
 import '../../../apps/actions/assets/timestamps.js'
 import '../../../apps/dashboard/assets/ajax_modal.js'
 import '../../../apps/maps/assets/map-address.js'

--- a/changelog/2735.md
+++ b/changelog/2735.md
@@ -1,4 +1,0 @@
-### Fixed
-
-- added poyfill for Object.hasOwn() to make comments work on older browsers
-  (e.g. safari 14) (#2735)

--- a/package.json
+++ b/package.json
@@ -64,7 +64,6 @@
     "@testing-library/react": "16.0.1",
     "babel-loader": "9.2.1",
     "copy-webpack-plugin": "12.0.2",
-    "core-js": "3.38.1",
     "eslint": "8.41.0",
     "eslint-config-standard": "17.0.0",
     "eslint-config-standard-jsx": "11.0.0",


### PR DESCRIPTION
…work on"

This reverts commit 85bc55865f64b883c751afb2c31da2bcfd9d8bfc.

We don't need to support Safari <= 15 anymore

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
