### PR TITLE
apps/projects: check if a creator is set for a poll answer/vote to ac…

### DIFF
--- a/apps/projects/signals.py
+++ b/apps/projects/signals.py
@@ -93,5 +93,6 @@ def increase_poll_answers_count(sender, instance, created, **kwargs):
 
         insight, _ = ProjectInsight.objects.get_or_create(project=project)
         insight.poll_answers += 1
-        insight.active_participants.add(instance.creator.id)
+        if instance.creator:
+            insight.active_participants.add(instance.creator.id)
         insight.save()

--- a/changelog/8381.md
+++ b/changelog/8381.md
@@ -1,0 +1,4 @@
+### Changed
+
+- add a check for the creator field in the Answer/Vote signal for the poll to
+accommodate the new feature to vote without registration


### PR DESCRIPTION
…commodate the new unregistered voting

**Tasks**
- [x] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog

depends on https://github.com/liqd/adhocracy4/pull/1683