### PR TITLE
assets/scss: show react captcha text mode correctly by excluding the

### DIFF
--- a/adhocracy-plus/assets/scss/components/_captcheck.scss
+++ b/adhocracy-plus/assets/scss/components/_captcheck.scss
@@ -46,7 +46,7 @@
     display: initial;
 }
 
-.captcheck_question_access {
+:not(.react_captcha).captcheck_question_access {
     display: none;
 }
 
@@ -79,6 +79,6 @@
     display: initial;
 }
 
-.captcheck_answer_access {
+:not(.react_captcha).captcheck_answer_access {
     display: none;
 }


### PR DESCRIPTION
display none styles for it.

Fixes the captcha in the poll for unregistered users

requires https://github.com/liqd/adhocracy4/pull/1690

fixes #2839 

Testing: create new poll and allow unregistered users, open poll in private tab or sign out

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
