### PR TITLE
Makefile: add docs command to see documentation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,6 +52,7 @@ help:
 	@echo "  make celery-worker-start		-- starts the celery worker in the foreground"
 	@echo "  make celery-worker-status		-- lists all registered tasks and active worker nodes"
 	@echo "  make celery-worker-dummy-task	-- calls the dummy task and prints result from redis"
+	@echo "  make docs                   	-- run the mkdocs server for the documentation"
 	@echo
 
 .PHONY: install
@@ -232,3 +233,7 @@ celery-worker-status:
 .PHONY: celery-worker-dummy-task
 celery-worker-dummy-task:
 	$(VIRTUAL_ENV)/bin/celery --app adhocracy-plus call dummy_task | awk '{print "celery-task-meta-"$$0}' | xargs redis-cli get | python3 -m json.tool
+
+.PHONY: docs
+docs:
+	$(VIRTUAL_ENV)/bin/mkdocs serve

--- a/changelog/_0002.md
+++ b/changelog/_0002.md
@@ -1,0 +1,4 @@
+### Added
+
+- added a new make command `docs` to run the mkdocs server to read (and see live
+changes to) the documentation


### PR DESCRIPTION
Added this as I keep forgetting the exact command, this way I can autocomplete it :)

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
