### PR TITLE
[#8499] a4-polls: create info box for unregistered users

### DIFF
--- a/adhocracy-plus/assets/scss/components/_info_box.scss
+++ b/adhocracy-plus/assets/scss/components/_info_box.scss
@@ -1,0 +1,21 @@
+.info-box {
+    background-color: $brand-primary-tint;
+    padding: $spacer;
+    margin: $spacer 0;
+    display: flex;
+    flex-direction: column;
+
+    &__content {
+        display: flex;
+        align-items: first baseline;
+        gap: $spacer; // Space between icon and text
+
+        p {
+            margin-bottom: 0;
+        }
+    }
+
+    &__text {
+        flex-grow: 1;
+    }
+}

--- a/adhocracy-plus/assets/scss/style.scss
+++ b/adhocracy-plus/assets/scss/style.scss
@@ -95,6 +95,7 @@
 @import "components/homepage";
 @import "components/homepage_hero";
 @import "components/idea_remark";
+@import "components/info_box";
 @import "components/infographic";
 @import "components/item_detail";
 @import "components/language_choice";

--- a/adhocracy-plus/templates/a4modules/includes/module_description.html
+++ b/adhocracy-plus/templates/a4modules/includes/module_description.html
@@ -1,0 +1,13 @@
+{% block module_description %}
+    {% if module.phases.first.type != 'a4_candy_interactive_events:issue' %}
+        <section class="row">
+            <div class="col-md-8 offset-md-2 mb-3">
+                <header>
+                    <h2>{{ module.name }}</h2>
+                </header>
+                {% include "a4polls/includes/unregistered-users-info-box.html" %}
+                <p>{{ module.description }}</p>
+            </div>
+        </section>
+    {% endif %}
+{% endblock module_description %}

--- a/adhocracy-plus/templates/a4modules/module_detail.html
+++ b/adhocracy-plus/templates/a4modules/module_detail.html
@@ -107,14 +107,9 @@
                         </li>
                     </ul>
                 </nav>
-                {% block module_description %}
-                    {% if module.phases.first.type != 'a4_candy_interactive_events:issue' %}
-                    <h1 class="project-header__title">{{ module.name }}</h1>
-                    <p class="project-header__description">{{ module.description }}</p>
-                    {% endif %}
-                {% endblock %}
             </div>
         </div>
+        {% include "a4modules/includes/module_description.html" %}
         {% block phase_info %}
             {% if module.phases.first.type != 'a4_candy_interactive_events:issue' %}
                 {% if not module.active_phase %}

--- a/adhocracy-plus/templates/a4polls/includes/unregistered-users-info-box.html
+++ b/adhocracy-plus/templates/a4polls/includes/unregistered-users-info-box.html
@@ -1,0 +1,20 @@
+{% load i18n static settings %}
+{% settings_value "APLUS_MANUAL_URL" as manual_url %}
+
+{% if poll.allow_unregistered_users %}
+    <aside class="info-box" aria-labelledby="info-box-title">
+        <h3 class="visually-hidden" id="info-box-title">{% translate "Poll Participation Info" %}</h3>
+        <div class="info-box__content">
+            <i class="far fa-lightbulb" aria-hidden="true"></i>
+            <div class="info-box__text">
+                {% blocktrans %}
+                    <p>You can now participate in this poll even if you're not logged in.</p>
+                    <p><strong>Unregistered users can't edit their votes once submitted.</strong></p>
+                {% endblocktrans %}
+                {% if manual_url %}
+                    <a href="{{ manual_url }}/{{ LANGUAGE_CODE }}:quickstart:faq:registration:poll" rel="nofollow noopener noreferrer external" target="_blank" class="info-box__link" aria-label="Learn more about the voting options and rules">{% translate "Learn more about voting options." %}</a>
+                {% endif %}
+            </div>
+        </div>
+    </aside>
+{% endif %}

--- a/apps/projects/templates/a4_candy_projects/project_detail.html
+++ b/apps/projects/templates/a4_candy_projects/project_detail.html
@@ -196,16 +196,7 @@
                     </div>
 
                     {% else %} <!-- if just one module and no phase view to dispatch to -->
-                    <div class="row">
-                        <div class="col-md-8 offset-md-2 mb-3">
-                            {% block module_description %}
-                                {% if module.phases.first.type != 'a4_candy_interactive_events:issue' %}
-                                <h1 class="project-header__title">{{ module.name }}</h1>
-                                <p class="project-header__description">{{ module.description }}</p>
-                                {% endif %}
-                            {% endblock %}
-                        </div>
-                    </div>
+                    {% include "a4modules/includes/module_description.html" %}
                     {% if module.phases.first.type != 'a4_candy_interactive_events:issue' %}
                         {% if not module.active_phase %}
                         <div class="row">

--- a/changelog/8499.md
+++ b/changelog/8499.md
@@ -1,0 +1,3 @@
+### Added
+- info-box on poll for unregistered users
+- module_description snippet with fixed semantics


### PR DESCRIPTION
### Polls UI customization: Info box for unregistered users
- created new snippet for the box
- refactored the module description to remove duplicates and make it more maintainable

#### Desktop
![Screenshot 2024-12-03 at 16-06-11 Private Project — adhocracy _liqd-orga](https://github.com/user-attachments/assets/5563620c-00bd-4c79-81d8-46366e34b8ac)

#### Mobile
<img src="https://github.com/user-attachments/assets/d9fa9afc-405b-416a-be90-782f9751c216" width="300px">
