### PR TITLE
settings/base.py: enable new open poll feature by default

### DIFF
--- a/adhocracy-plus/config/settings/base.py
+++ b/adhocracy-plus/config/settings/base.py
@@ -444,6 +444,9 @@ WAGTAILIMAGES_IMAGE_MODEL = "a4_candy_cms_images.CustomImage"
 
 A4_ORGANISATIONS_MODEL = "a4_candy_organisations.Organisation"
 
+# Set to False to disable the option to allow unregistered users in polls
+A4_POLL_ENABLE_UNREGISTERED_USERS = True
+
 A4_RATEABLES = (
     ("a4comments", "comment"),
     ("a4_candy_ideas", "idea"),


### PR DESCRIPTION
Enable the option to create open polls by default (I don't really see a reason not to allow it by default).

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
