### PR TITLE
poll-slider: use padding instead of margin to fix errors with long an…

### DIFF
--- a/adhocracy-plus/assets/scss/components/_a4-poll.scss
+++ b/adhocracy-plus/assets/scss/components/_a4-poll.scss
@@ -236,10 +236,10 @@ $checkbox-size: 20px;
     .slick-slide {
         height: auto;
         position: relative;
-        margin: 0 $spacer 0 (2 * $spacer);
+        padding: 0 $spacer 0 (2 * $spacer);
 
         @media (min-width: $breakpoint) {
-            margin: 0 3 * $spacer;
+            padding: 0 3 * $spacer;
         }
     }
 

--- a/changelog/_0004.md
+++ b/changelog/_0004.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- fix other answers in the poll-slider overlapping on long text.


### PR DESCRIPTION
…swers

fixes #2886

**old** 
![Screenshot 2025-01-06 at 14-18-43 poll — adhocracy _liqd-orga](https://github.com/user-attachments/assets/0283093d-f0a3-46e3-a736-9293c2b021a2)

**new**
![Screenshot 2025-01-06 at 14-19-22 poll — adhocracy _liqd-orga](https://github.com/user-attachments/assets/b9d3594e-e894-4e99-996e-b87fc284096d)


**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog
