### PR TITLE
apps/cms: change helptext for captcha on contact form

### DIFF
--- a/apps/cms/contacts/models.py
+++ b/apps/cms/contacts/models.py
@@ -18,7 +18,9 @@ from wagtail.fields import RichTextField
 
 from apps.captcha.fields import CaptcheckCaptchaField
 from apps.cms.emails import AnswerToContactFormEmail
+from apps.cms.settings import helpers
 from apps.contrib.translations import TranslatedField
+from apps.users.forms import CAPTCHA_HELP
 
 
 class FormField(AbstractFormField):
@@ -33,9 +35,7 @@ class WagtailCaptchaFormBuilder(FormBuilder):
         if hasattr(settings, "CAPTCHA_URL") and settings.CAPTCHA_URL:
             fields["captcha"] = CaptcheckCaptchaField(
                 label=_("I am not a robot"),
-                help_text=_(
-                    "If you are having difficulty please contact" "us, details adjacent"
-                ),
+                help_text=helpers.add_email_link_to_helptext("", CAPTCHA_HELP),
             )
 
         return fields

--- a/apps/users/forms.py
+++ b/apps/users/forms.py
@@ -20,8 +20,8 @@ from apps.users.models import User
 logger = logging.getLogger(__name__)
 
 CAPTCHA_HELP = _(
-    "Solve the math problem and click on the correct result.<br>"
-    "If you are having difficulty please contact us  by {}email{}."
+    "Solve the math problem and click on the correct result.<strong>"
+    "If you are having difficulty please contact us  by {}email{}.</strong>"
 )
 
 

--- a/changelog/_0001.md
+++ b/changelog/_0001.md
@@ -1,0 +1,6 @@
+### Changed
+
+- change captcha helptext on contact form to be identical to the sign up form
+captcha
+- remove the broken <br> tag from the captcha helptext and replace it with
+<strong>


### PR DESCRIPTION
- make contact form and signup use the same captcha helptext and replace the broken <br> tag with <strong>.

fixes #2843

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog
