### PR TITLE
remove stylelint workaround

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,6 @@
     "eslint-plugin-promise": "6.1.1",
     "eslint-plugin-react": "7.32.2",
     "husky": "9.1.7",
-    "ignore": "7.0.3",
     "jest": "29.7.0",
     "jest-environment-jsdom": "29.7.0",
     "lint-staged": "15.3.0",


### PR DESCRIPTION
They already released a fixed version, so we don't need the workaround any more

**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
