### PR TITLE
[#2732] Increase margin on badges

### DIFF
--- a/adhocracy-plus/assets/scss/components/_badge.scss
+++ b/adhocracy-plus/assets/scss/components/_badge.scss
@@ -1,3 +1,4 @@
+
 .badge {
     display: inline-block;
     background-color: $text-color;
@@ -5,6 +6,7 @@
     font-size: $font-size-xs;
     font-weight: normal;
     border-radius: 0.4em;
+    margin-bottom: 0.2em;
     padding: 0.2em 0.7em;
     text-align: start;
     white-space: normal;

--- a/adhocracy-plus/assets/scss/components/_organisation.scss
+++ b/adhocracy-plus/assets/scss/components/_organisation.scss
@@ -36,11 +36,11 @@
 }
 
 .organisation__social-link {
-    width: 2rem;
-    height: 2rem;
+    width: 4rem;
+    height: 4rem;
     position: relative;
     background-color: $brand-secondary;
-    border-radius: 8rem;
+    border-radius: 10rem;
 
     i {
         position: absolute;
@@ -48,6 +48,7 @@
         left: 50%;
         transform: translate(-50%, -50%);
         width: 50%;
-        color: $white;
+        font-size: 1.8rem;
+        color: $black;
     }
 }

--- a/apps/contrib/templates/a4_candy_contrib/component_library.html
+++ b/apps/contrib/templates/a4_candy_contrib/component_library.html
@@ -1,8 +1,9 @@
 {% extends 'base.html' %}
 
-{% block title %}Component Library — {{ block.super }}{% endblock %}
+{% block title %}Component Library — {{ block.super }}{% endblock title %}
 
 {% block content %}
+{# djlint:off #}
 <div class="container">
     <div class="row">
         <div class="col-md-3">
@@ -1525,6 +1526,26 @@
 
                     <div class="item-detail__labels">
                         <div class="badge badge--big">Label</div>
+                        <div class="badge badge--big">Label</div>
+                        <div class="badge badge--big">Label</div>
+                        <div class="badge badge--big">Label</div>
+                        <div class="badge badge--big">Label</div>
+                        <div class="badge badge--big">Label</div>
+                        <div class="badge badge--big">Label</div>
+                        <div class="badge badge--big">Label</div>
+                        <div class="badge badge--big">Label</div>
+                        <div class="badge badge--big">Label</div>
+                        <div class="badge badge--big">Label</div>
+                        <div class="badge badge--big">Label</div>
+                        <div class="badge badge--big">Label</div>
+                        <div class="badge badge--big">Label</div>
+                        <div class="badge badge--big">Label</div>
+                        <div class="badge badge--big">Label</div>
+                        <div class="badge badge--big">Label</div>
+                        <div class="badge badge--big">Label</div>
+                        <div class="badge badge--big">Label</div>
+                        <div class="badge badge--big">Label</div>
+                        <div class="badge badge--big">Label</div>
                     </div>
 
                     <div class="item-detail__content">
@@ -2425,4 +2446,5 @@
         </div>
     </div>
 </div>
+{# djlint:on #}
 {% endblock content %}

--- a/changelog/2732.md
+++ b/changelog/2732.md
@@ -1,0 +1,1 @@
+- **Fixed**: Add space for multi-row badges


### PR DESCRIPTION
Added margin to the bottom of the badges, this increases the space below.

https://github.com/liqd/adhocracy-plus/issues/2732

I considered refactoring the code to be flexbox ([example](https://www.material-tailwind.com/docs/html/badge)), but decided it touched too many components I'm unsure how to test. Should refactering it be on our technical backlog? As the current solution adds space even when the row is not wrapped. 

I also added {# djlint:off #} to component library to mute linting, as this is hand coded html, not representing the component code strictly. Another task for the technical backlog might be building a component library that uses our components in situe, so they are representative of our code as it changes. 

**Tasks**
- [ x] PR name contains story or task reference
- [ -] Documentation (docs and inline)
- [ -] Tests (including n+1 and django_assert_num_queries where applicable)
- [ x] Changelog
