### PR TITLE
users: add captcha for SSO registration

### DIFF
--- a/changelog/232.md
+++ b/changelog/232.md
@@ -1,0 +1,3 @@
+### Added
+
+- captcha required for all SSO social signups


### PR DESCRIPTION
[STS-232](https://app.asana.com/1/1175467295883992/inbox/1209159381077685/item/1210053730373688/story/1210451705078056)

Adds captcha to the end of the SSO flow: after authentication with eg facebook, but before a new account is created.

I expect this to work, but have not tested because it's tricky to do it locally. Proposing we test on dev if we have a test facebook environment ready there? 

There are also no existing tests for SSO afaik, for the same reason.
