### PR TITLE
templates: fix social captcha rendered twice

### DIFF
--- a/adhocracy-plus/templates/socialaccount/signup.html
+++ b/adhocracy-plus/templates/socialaccount/signup.html
@@ -15,8 +15,10 @@
         {{ form.media }}
         {% csrf_token %}
         {% for hidden in form.hidden_fields %}
+            {% if hidden.name != 'captcha' %}
                 {{ hidden }}
                 {{ hidden.errors }}
+            {% endif %}
         {% endfor %}
 
         <div class="form-group">


### PR DESCRIPTION
STS-232

Adds to https://github.com/liqd/adhocracy-plus/pull/2951 https://github.com/liqd/adhocracy-plus/pull/2953 #2954 

Captcha is rendering now, but twice. The widget is inherits from `widgets.HiddenInput` because it has a hidden field, but on social signup what's different from [regular signup](https://github.com/liqd/adhocracy-plus/blob/f61a8c5dadd1764129d04d504267049d711c95af/adhocracy-plus/templates/account/signup.html) is we're using a hidden field to collect the email address. This fix skips over the captcha when rendering hidden fields, so we only render the captcha when it appears later in the form template.