### PR TITLE
templates: add next param for github oauth sso

### DIFF
--- a/adhocracy-plus/templates/socialaccount/snippets/provider_list.html
+++ b/adhocracy-plus/templates/socialaccount/snippets/provider_list.html
@@ -17,6 +17,8 @@
                         href="
                             {% if provider.id == 'github' %}
                                 {% provider_login_url provider.id openid=brand.openid_url process=process next='/accounts/3rdparty/signup/' %}
+                            {% elif provider.id == 'apple' %}
+                                {% provider_login_url provider.id openid=brand.openid_url process=process next='/accounts/apple/callback/' %}
                             {% else %}
                                 {% provider_login_url provider.id openid=brand.openid_url process=process %}
                             {% endif %}


### PR DESCRIPTION
STS-232

Adds to https://github.com/liqd/adhocracy-plus/pull/2951 https://github.com/liqd/adhocracy-plus/pull/2953 https://github.com/liqd/adhocracy-plus/pull/2954 #2955

Github uses oath, which seems like needs to have redirect explicitly defined as query param when routed to. This conditionally gives that param for github only, as not sure if it would interfere with other providers, which currently work in testing.