### PR TITLE
fixes for datepicker, moderator feedback, location module

### DIFF
--- a/adhocracy-plus/assets/scss/components/_datepicker.scss
+++ b/adhocracy-plus/assets/scss/components/_datepicker.scss
@@ -8,7 +8,6 @@
     // Prevents erroneously selecting entire page on incidental click + drag
     // because of high z-index of the date picker.
     user-select: none;
-    -webkit-user-select: none;
 
     select {
         display: unset;

--- a/adhocracy-plus/assets/scss/components/_datepicker.scss
+++ b/adhocracy-plus/assets/scss/components/_datepicker.scss
@@ -4,6 +4,12 @@
 
 .flatpickr-calendar {
     // overwrite style from _form.scss
+
+    // Prevents erroneously selecting entire page on incidental click + drag
+    // because of high z-index of the date picker.
+    user-select: none;
+    -webkit-user-select: none;
+
     select {
         display: unset;
     }

--- a/adhocracy-plus/templates/a4dashboard/base_dashboard_project.html
+++ b/adhocracy-plus/templates/a4dashboard/base_dashboard_project.html
@@ -42,7 +42,7 @@
                 </div>
                 <ul class="dashboard-nav__pages collapse{% if not project.id in closed_accordions.0 %} show{% endif %}" id="dashboardCollapseProj" aria-hidden="false">
                     {% for item in dashboard_menu.project %}
-                        {% if item.label != "Location" or project.organisation.enable_geolocation %}
+                        {% if item.identifier != "location" or project.organisation.enable_geolocation %}
                             <li class="dashboard-nav__page">
                                 <a href="{{ item.url }}"
                                     class="dashboard-nav__item dashboard-nav__item--interactive {{ item.is_active|yesno:"is-active," }}">
@@ -50,6 +50,7 @@
                                     <i class="fa fa-exclamation-circle text-danger" title="{% translate "Missing fields for publication" %}" aria-label="{% translate "Missing fields for publication" %}"></i>
                                 {% endif %}
                                     {{ item.label }}
+                                    {{ item.identifier }}
                                 </a>
                             </li>
                         {% endif %}

--- a/apps/userdashboard/assets/js/a4_candy_userdashboard/ModerationFeedbackForm.jsx
+++ b/apps/userdashboard/assets/js/a4_candy_userdashboard/ModerationFeedbackForm.jsx
@@ -1,6 +1,8 @@
 import React, { useState } from 'react'
 import django from 'django'
 
+const MODERATOR_FEEDBACK_MAX_LENGTH = 500
+
 export const ModerationFeedbackForm = (props) => {
   const [feedback, setFeedback] =
     useState((props.editing && props.initialFeedback.feedback_text) || '')
@@ -28,10 +30,11 @@ export const ModerationFeedbackForm = (props) => {
         placeholder={translated.placeholder}
         onChange={(e) => setFeedback(e.target.value)}
         value={feedback}
+        maxLength={MODERATOR_FEEDBACK_MAX_LENGTH}
       />
       <div className="row">
         <label htmlFor="id-comment-form" className="col-6 a4-comments__char-count">
-          {feedback.length}/500{translated.charCount}
+          {feedback.length}/{MODERATOR_FEEDBACK_MAX_LENGTH}{translated.charCount}
         </label>
         <div className="a4-comments__submit d-flex col-6">
           <button

--- a/changelog/8407.md
+++ b/changelog/8407.md
@@ -1,0 +1,3 @@
+### Fixed
+
+- dashboard/phases: Prevent accidental selection of entire page when using date picker

--- a/changelog/845.md
+++ b/changelog/845.md
@@ -1,0 +1,7 @@
+### Fixed
+
+- Conditional display of dashboard project module menu's "Location" uses identifier instead of label, so translation doesn't break it
+
+### Added 
+
+- Added moderator feedback form textarea character limit of 500


### PR DESCRIPTION
Fixes toward [milestone](https://github.com/liqd/adhocracy-plus/issues?q=is%3Aissue%20state%3Aopen%20milestone%3A%22release%20july%202025%22):

Dashboard: phase datepicker lets user accidentally select entire page
https://github.com/liqd/adhocracy-plus/issues/2837 / https://app.asana.com/1/1175467295883992/project/1209245838104549/task/1210876321384674?focus=true

Dashboard: bug where location / ort dashboard module shows up when switching to german language
https://github.com/liqd/adhocracy-plus/issues/2938 / https://app.asana.com/1/1175467295883992/project/1209245838104549/task/1210868049976111?focus=true
Depends on a4 PR: https://github.com/liqd/adhocracy4/pull/1803

Moderator feedback comment textarea limit to 500 characters
https://github.com/liqd/adhocracy-plus/issues/2708 / https://app.asana.com/1/1175467295883992/project/1209245838104549/task/1210876321384673