### PR TITLE
assets/js: use flatpickr non-native ui on mobile

### DIFF
--- a/adhocracy-plus/assets/js/init-picker.js
+++ b/adhocracy-plus/assets/js/init-picker.js
@@ -68,7 +68,11 @@ function initDatePicker () {
   // Initialize date pickers
   document.querySelectorAll('.datepicker').forEach((element) => {
     element.classList.add('form-control')
-    const datePicker = flatpickr(element, { dateFormat, locale: lang })
+    const datePicker = flatpickr(element, {
+      disableMobile: true,
+      dateFormat,
+      locale: lang
+    })
     flatpickrsMap.set(element.id, datePicker)
   })
 

--- a/changelog/2967.md
+++ b/changelog/2967.md
@@ -1,0 +1,3 @@
+# Changed
+
+- phase date selection: use flatpickr's ui on mobile instead of native


### PR DESCRIPTION
on mobile native, min/max dates weren't being followed, so this changes flatpickr config to disallow native ui on mobile and use the package's ui instead always.

https://github.com/liqd/adhocracy-plus/issues/2838
https://app.asana.com/1/1175467295883992/project/1208559589495764/task/1210876321384671?focus=true