### PR TITLE
[ST-1940] add custom email sender using a4 get_from_email

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,12 @@ This project (not yet) adheres to [Semantic Versioning](https://semver.org/spec/
 - Idea, proposal, and map idea forms: do not prefill contact email for guest users
 - Project detail: follower count and avatar bubbles exclude guest users
 - Project banner for guests: register links to guest account conversion; login routes through sign-out before the login page
+- Emails: organisation-scoped mailings (notifications, invitations, newsletters,
+  report-to-moderator, etc.) show ``{organisation name} | {platform/site name}`` as the
+  sender display name (from Wagtail ``OrganisationSettings.platform_name`` or the
+  Django site name). SMTP address still comes from ``DEFAULT_FROM_EMAIL``.
+  Implemented in ``EmailAplus.get_from_email()``; a4 report emails are wired via
+  ``apps/contrib/a4_emails.py``.
 
 ### Fixed
 

--- a/adhocracy-plus/config/settings/base.py
+++ b/adhocracy-plus/config/settings/base.py
@@ -327,6 +327,9 @@ SOCIALACCOUNT_EMAIL_AUTHENTICATION_AUTO_CONNECT = True
 LOGIN_URL = "account_login"
 LOGIN_REDIRECT_URL = "/"
 
+# Outgoing mail (see docs/installation_prod.md). Set DEFAULT_FROM_EMAIL in
+# production local settings to your SMTP sender address. Organisation-scoped
+# emails add a display name via EmailAplus (``{organisation} | {site name}``).
 EMAIL_BACKEND = "django.core.mail.backends.console.EmailBackend"
 
 # Rest Framework

--- a/apps/contrib/a4_emails.py
+++ b/apps/contrib/a4_emails.py
@@ -1,0 +1,23 @@
+"""Wire adhocracy4 email classes into adhocracy-plus.
+
+adhocracy4 ships some emails (e.g. report-to-moderator) on its base ``Email``
+class, which does not use ``EmailAplus``. At startup we replace those classes
+with ``EmailAplus`` subclasses so they pick up organisation-branded sender names
+and other a+ behaviour (see ``apps/users/emails.py``).
+"""
+
+
+def patch_report_moderator_email():
+    from adhocracy4.reports import emails as reports_emails
+    from apps.users.emails import EmailAplus
+
+    class ReportModeratorEmail(EmailAplus):
+        template_name = "a4reports/emails/report_moderators"
+
+        def get_organisation(self):
+            return self.object.project.organisation
+
+        def get_receivers(self):
+            return self.object.project.moderators.all()
+
+    reports_emails.ReportModeratorEmail = ReportModeratorEmail

--- a/apps/contrib/apps.py
+++ b/apps/contrib/apps.py
@@ -4,3 +4,8 @@ from django.apps import AppConfig
 class Config(AppConfig):
     name = "apps.contrib"
     label = "a4_candy_contrib"
+
+    def ready(self):
+        from apps.contrib.a4_emails import patch_report_moderator_email
+
+        patch_report_moderator_email()

--- a/apps/users/emails.py
+++ b/apps/users/emails.py
@@ -1,4 +1,6 @@
 from email.mime.image import MIMEImage
+from email.utils import formataddr
+from email.utils import parseaddr
 
 import magic
 from django.conf import settings
@@ -22,8 +24,25 @@ PROJECT_LINK_TEXT = _(
     "this project, unsubscribe from the {}project{}."
 )
 
+# Fallback when no platform or site name is configured (see get_platform_name()).
+DEFAULT_PLATFORM_SENDER_NAME = "adhocracy.plus"
+
 
 class EmailAplus(Email):
+    def get_sender_display_name(self):
+        platform_name = self.get_platform_name() or DEFAULT_PLATFORM_SENDER_NAME
+        organisation = self.get_organisation()
+        if organisation is not None:
+            return f"{organisation.name} | {platform_name}"
+        return platform_name
+
+    # Uses a4 EmailBase.get_from_email() hook; address from DEFAULT_FROM_EMAIL.
+    def get_from_email(self):
+        _, address = parseaddr(settings.DEFAULT_FROM_EMAIL)
+        if not address:
+            address = settings.DEFAULT_FROM_EMAIL
+        return formataddr((self.get_sender_display_name(), address))
+
     def get_languages(self, receiver):
         languages = super().get_languages(receiver)
         organisation = self.get_organisation()

--- a/docs/installation_prod.md
+++ b/docs/installation_prod.md
@@ -70,6 +70,9 @@ DATABASES = {
 # forward outgoing emails to a local email proxy
 EMAIL_BACKEND='django.core.mail.backends.smtp.EmailBackend'
 EMAIL_HOST='127.0.0.1'
+# SMTP sender address (envelope). Organisation-scoped emails add a display name
+# automatically: "{organisation name} | {platform/site name}" (see docs/notifications.md).
+DEFAULT_FROM_EMAIL='noreply@your.domain'
 
 # folder for user-uploads, directly served from the webserver (see nginx example below). Must be created manually.
 MEDIA_ROOT='/home/aplus/aplus-media'

--- a/docs/notifications.md
+++ b/docs/notifications.md
@@ -76,3 +76,11 @@ which are rendered using the templates:
 `apps/notifications/templates/a4_candy_notifications/_notification_list.html`
 
 and each individual notification is loaded via filter `render_notification_with_links()` (`apps/notifications/templatetags/notification_tags.py`)
+
+### Email delivery
+
+Notification emails are sent through `NotificationEmail` (`apps/notifications/services.py`), which subclasses `EmailAplus` (`apps/users/emails.py`).
+
+Organisation-scoped emails use the visible sender name `{organisation name} | {platform name}`. The platform name comes from Wagtail `OrganisationSettings.platform_name` on the default site, or falls back to the Django site name (`get_platform_name()` in `apps/users/emails.py`). The SMTP address is taken from Django's `DEFAULT_FROM_EMAIL` setting (configure in production — see `docs/installation_prod.md`). Account-related mails without an organisation use the platform/site name only.
+
+adhocracy4's built-in report-to-moderator email is patched at startup in `apps/contrib/a4_emails.py` so it uses the same sender behaviour.

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "@uppy/dashboard": "^5.1.1",
         "@uppy/image-editor": "^4.2.0",
         "@uppy/locales": "^5.1.1",
-        "adhocracy4": "github:liqd/adhocracy4#aplus-v2607.3",
+        "adhocracy4": "github:liqd/adhocracy4#main",
         "autoprefixer": "10.4.20",
         "bootstrap": "5.2.3",
         "css-loader": "7.1.4",
@@ -8947,7 +8947,7 @@
     },
     "node_modules/adhocracy4": {
       "version": "1.0.0",
-      "resolved": "git+ssh://git@github.com/liqd/adhocracy4.git#e4ee63ba40067d7cf72fced463c64f90da07bd22",
+      "resolved": "git+ssh://git@github.com/liqd/adhocracy4.git#b439eb9cb1c7205e5f207a0077dbdbc436ce5991",
       "license": "AGPL-3.0+",
       "dependencies": {
         "@popperjs/core": "2.11.8",

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "@uppy/dashboard": "^5.1.1",
     "@uppy/image-editor": "^4.2.0",
     "@uppy/locales": "^5.1.1",
-    "adhocracy4": "github:liqd/adhocracy4#aplus-v2607.3",
+    "adhocracy4": "github:liqd/adhocracy4#main",
     "autoprefixer": "10.4.20",
     "bootstrap": "5.2.3",
     "css-loader": "7.1.4",

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+https://github.com/liqd/adhocracy4.git@aplus-v2607.3
+git+https://github.com/liqd/adhocracy4.git
 
 # Additional requirements
 brotli==1.2.0

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -1,5 +1,5 @@
 # A4
-git+https://github.com/liqd/adhocracy4.git
+git+https://github.com/liqd/adhocracy4.git@main
 
 # Additional requirements
 brotli==1.2.0

--- a/tests/contrib/test_aplus_email.py
+++ b/tests/contrib/test_aplus_email.py
@@ -1,5 +1,36 @@
+from email.utils import parseaddr
+
 import pytest
 from django.core import mail
+
+from apps.account.emails import AccountDeletionEmail
+
+
+@pytest.mark.django_db
+def test_aplus_email_from_name_with_organisation(
+    organisation_factory,
+    project_factory,
+    module_factory,
+    idea_factory,
+):
+    organisation = organisation_factory(name="City Council")
+    project = project_factory(organisation=organisation)
+    module = module_factory(project=project)
+    idea_factory(module=module)
+
+    display_name, _ = parseaddr(mail.outbox[0].from_email)
+    org_name, platform_name = display_name.split(" | ", 1)
+    assert org_name == "City Council"
+    assert platform_name
+
+
+@pytest.mark.django_db
+def test_aplus_email_from_name_without_organisation(user):
+    AccountDeletionEmail.send(user)
+
+    display_name, _ = parseaddr(mail.outbox[0].from_email)
+    assert display_name
+    assert " | " not in display_name
 
 
 @pytest.mark.django_db


### PR DESCRIPTION
**Tasks**
- [ ] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog


:.::..:::::: [Aligned Asana Task](https://app.asana.com/1/1175467295883992/project/1208559589495764/task/1210121016944736) ::.:.::.::::