### PR TITLE
[ST-2689] apps/moduls Phase display on module pages

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,8 @@ This project (not yet) adheres to [Semantic Versioning](https://semver.org/spec/
 
 ### Changed
 
+- Module page: replace the running phase description with a table listing all phases
+  (name, start date, end date and status completed/active/upcoming)
 - Organisation page: redesigned with overlapping logo, about link, organisation stats, project search and project tiles in a three column grid
 - Landing Page: Updated buttons (view demo organisation), new icons
 - Idea, proposal, and map idea forms: do not prefill contact email for guest users

--- a/adhocracy-plus/assets/scss/components/_project_detail.scss
+++ b/adhocracy-plus/assets/scss/components/_project_detail.scss
@@ -170,6 +170,112 @@ $project-detail-breadcrumbs-offset: 79px;
 
 .project-detail__module-phases {
     width: 100%;
+    margin-bottom: 1.5 * $spacer;
+
+    &:last-child {
+        margin-bottom: 0;
+    }
+}
+
+$project-detail-phase-border: #DFDEDE;
+$project-detail-phase-gap: 1.25 * $spacer;
+
+.project-detail__module-phases .phase-info__item {
+    margin-bottom: $project-detail-phase-gap;
+
+    &:last-child {
+        margin-bottom: 0;
+    }
+}
+
+.project-detail__module-phases .phase-info__item__header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: $spacer;
+    margin-bottom: $project-detail-phase-gap;
+}
+
+.project-detail__module-phases .phase-info__item__name {
+    font-size: $font-size-sm;
+    font-weight: $demi-bold;
+    line-height: 1.5;
+}
+
+.project-detail__module-phases .phase-status-badge {
+    display: inline-flex;
+    align-items: center;
+    padding: 0 0.625rem;
+    border-radius: 5px;
+    font-size: 0.75rem;
+    font-weight: 400;
+    line-height: 1.6;
+    white-space: nowrap;
+
+    // Completed
+    &--completed {
+        background-color: $grey-100;
+        color: $grey-700;
+    }
+
+    // Active
+    &--active {
+        background-color: $feedback-color-accepted;
+        color: $text-colour;
+    }
+
+    // Upcoming
+    &--upcoming {
+        background-color: $text-colour;
+        color: $white;
+    }
+}
+
+.project-detail__module-phases .phase-info__item__details {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: $spacer;
+    padding: 0.625rem 0;
+    border-top: 1px solid $project-detail-phase-border;
+    border-bottom: 1px solid $project-detail-phase-border;
+
+    @media (max-width: $breakpoint-down) {
+        flex-wrap: wrap;
+    }
+}
+
+.project-detail__module-phases .phase-info__item__detail {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 0.25 * $spacer;
+    min-width: 0;
+    text-align: center;
+}
+
+.project-detail__module-phases .phase-info__item__detail-label {
+    font-size: $font-size-sm;
+    font-weight: 400;
+    color: $text-color;
+}
+
+.project-detail__module-phases .phase-info__item__detail-value {
+    font-size: $font-size-sm;
+    font-weight: $demi-bold;
+    color: $text-color;
+    line-height: 1.5;
+
+    time {
+        font-weight: inherit;
+    }
+}
+
+.project-detail__module-phases .phase-info__item__description {
+    margin-top: $project-detail-phase-gap;
+    font-size: $font-size-sm;
+    font-weight: 400;
+    line-height: 1.5;
 }
 
 .project-detail__other-modules {

--- a/adhocracy-plus/templates/a4modules/includes/module_phases.html
+++ b/adhocracy-plus/templates/a4modules/includes/module_phases.html
@@ -1,0 +1,40 @@
+{% load i18n a4_candy_project_tags contrib_tags %}
+
+<div class="project-detail__module-phases">
+    {% for phase in module.phases %}
+    {% phase_status_tag phase as phase_status %}
+    <div class="phase-info__item">
+        <div class="phase-info__item__header">
+            <div class="phase-info__item__name">{{ phase.name }}</div>
+            <span class="phase-status-badge phase-status-badge--{{ phase_status.modifier }}">
+                {{ phase_status.label }}
+            </span>
+        </div>
+        <div class="phase-info__item__details">
+            <div class="phase-info__item__detail">
+                <span class="phase-info__item__detail-label">{% translate 'Start' %}</span>
+                <div class="phase-info__item__detail-value">
+                    {% html_date phase.start_date 'DATE_FORMAT' %}<br>
+                    {% html_date phase.start_date 'TIME_FORMAT' %}
+                </div>
+            </div>
+            <div class="phase-info__item__detail">
+                <span class="phase-info__item__detail-label">{% translate 'Duration' %}</span>
+                <div class="phase-info__item__detail-value">
+                    {% phase_duration phase %}
+                </div>
+            </div>
+            <div class="phase-info__item__detail">
+                <span class="phase-info__item__detail-label">{% translate 'End' %}</span>
+                <div class="phase-info__item__detail-value">
+                    {% html_date phase.end_date 'DATE_FORMAT' %}<br>
+                    {% html_date phase.end_date 'TIME_FORMAT' %}
+                </div>
+            </div>
+        </div>
+        <div class="phase-info__item__description">
+            {{ phase.description }}
+        </div>
+    </div>
+    {% endfor %}
+</div>

--- a/adhocracy-plus/templates/a4modules/module_detail.html
+++ b/adhocracy-plus/templates/a4modules/module_detail.html
@@ -91,31 +91,7 @@
                                 </strong>
                             </p>
                             {% endif %}
-                            {% with phase_count=module.phases.count %}
-                            <div class="project-detail__module-phases mb-4">
-                                {% for phase in module.phases %}
-                                    {% if phase.is_over or phase == module.active_phase %}
-                                    <div class="phase-info__item {% if phase_count == 1 %} u-no-border {% endif %}">
-                                        <div class="fw-bold{% if phase == module.active_phase %} lr-bar{% endif %}">
-                                            {% if phase == module.active_phase %}
-                                                <span class="lr-bar__left">{{ phase.name }}</span>
-                                                <span class="lr-bar__right text-primary">{% translate 'active' %}</span>
-                                            {% else %}
-                                                {{ phase.name }}
-                                            {% endif %}
-                                        </div>
-                                        <div class="phase-info__item__subtitle">
-                                            {% html_date phase.start_date 'DATETIME_FORMAT' %}
-                                            – {% html_date phase.end_date 'DATETIME_FORMAT' %}
-                                        </div>
-                                        <div class="phase-info__item__description">
-                                            {{ phase.description }}
-                                        </div>
-                                    </div>
-                                    {% endif %}
-                                {% endfor %}
-                            </div>
-                            {% endwith %}
+                            {% include "a4modules/includes/module_phases.html" %}
                         {% endif %}
                     {% endblock phase_info %}
 

--- a/apps/projects/templates/a4_candy_projects/project_detail.html
+++ b/apps/projects/templates/a4_candy_projects/project_detail.html
@@ -193,33 +193,7 @@
                             </div>
                         </div>
                         {% endif %}
-                        {% with phase_count=module.phases.count %}
-                        <div class="row">
-                            <div class="col-md-10 col-lg-8 offset-md-1 offset-lg-2">
-                                {% for phase in module.phases %}
-                                    {% if phase.is_over or phase == module.active_phase %}
-                                    <div class="phase-info__item {% if phase_count == 1 %} u-no-border {% endif %}">
-                                        <div class="fw-bold{% if phase == module.active_phase %} lr-bar{% endif %}">
-                                            {% if phase == module.active_phase %}
-                                                <span class="lr-bar__left">{{ phase.name }}</span>
-                                                <span class="lr-bar__right text-primary">{% translate 'active' %}</span>
-                                            {% else %}
-                                                {{ phase.name }}
-                                            {% endif %}
-                                        </div>
-                                        <div class="phase-info__item__subtitle">
-                                            {% html_date phase.start_date 'DATETIME_FORMAT' %}
-                                            – {% html_date phase.end_date 'DATETIME_FORMAT' %}
-                                        </div>
-                                        <div class="phase-info__item__description">
-                                            {{ phase.description }}
-                                        </div>
-                                    </div>
-                                    {% endif %}
-                                {% endfor %}
-                            </div>
-                        </div>
-                        {% endwith %}
+                        {% include "a4modules/includes/module_phases.html" %}
                     {% endif %}
                     {% endif %}
                 </div>

--- a/apps/projects/templatetags/a4_candy_project_tags.py
+++ b/apps/projects/templatetags/a4_candy_project_tags.py
@@ -28,6 +28,10 @@ from apps.projects.timeline import (
 from apps.projects.timeline import (
     offline_event_participation_status as get_offline_event_participation_status,
 )
+from apps.projects.timeline import phase_duration_label as get_phase_duration_label
+from apps.projects.timeline import (
+    phase_participation_status as get_phase_participation_status,
+)
 from apps.projects.utils import project_has_result_content
 
 register = template.Library()
@@ -92,6 +96,19 @@ def module_date_range(module):
 @register.simple_tag
 def module_cta_label(module):
     return get_module_cta_label(module)
+
+
+@register.simple_tag
+def phase_status_tag(phase):
+    """Return label and BEM modifier for a phase on the module detail page."""
+    status, label = get_phase_participation_status(phase)
+    return {"label": label, "modifier": status}
+
+
+@register.simple_tag
+def phase_duration(phase):
+    """Return a human readable duration for a phase, e.g. '3 months'."""
+    return get_phase_duration_label(phase)
 
 
 @register.simple_tag

--- a/apps/projects/timeline.py
+++ b/apps/projects/timeline.py
@@ -11,6 +11,7 @@ from typing import TYPE_CHECKING
 from django.utils import timezone
 from django.utils.formats import date_format
 from django.utils.translation import gettext_lazy as _
+from django.utils.translation import ngettext as _n
 
 if TYPE_CHECKING:
     from adhocracy4.modules.models import Module
@@ -20,6 +21,15 @@ if TYPE_CHECKING:
 STATUS_FINISHED = "finished"
 STATUS_RUNNING = "running"
 STATUS_UPCOMING = "upcoming"
+
+PHASE_STATUS_COMPLETED = "completed"
+PHASE_STATUS_ACTIVE = "active"
+
+_PHASE_STATUS_LABELS = {
+    PHASE_STATUS_COMPLETED: _("Completed"),
+    PHASE_STATUS_ACTIVE: _("Active"),
+    STATUS_UPCOMING: _("Upcoming"),
+}
 
 _STATUS_LABELS = {
     STATUS_FINISHED: _("Finished"),
@@ -67,6 +77,61 @@ def module_participation_status(module: Module) -> tuple[str, str]:
 
 
 participation_timeline_status = module_participation_status
+
+
+def phase_participation_status(phase) -> tuple[str, str]:
+    """
+    Return (status key, translated label) for one phase.
+
+    The status mirrors adhocracy4's phase semantics: a phase is completed
+    once ``phase.is_over`` is True, active while it is inside
+    ``phase.module.active_phases()`` (``start_date <= now < end_date``) and
+    upcoming otherwise. Staying close to ``Phase.is_over`` and
+    ``active_phases()`` keeps the badge consistent with
+    ``module.active_phase`` and the "participation is not possible" notice.
+    """
+    if phase.is_over:
+        return PHASE_STATUS_COMPLETED, _PHASE_STATUS_LABELS[PHASE_STATUS_COMPLETED]
+    now = timezone.now()
+    if (
+        phase.start_date
+        and phase.start_date <= now
+        and phase.end_date
+        and phase.end_date > now
+    ):
+        return PHASE_STATUS_ACTIVE, _PHASE_STATUS_LABELS[PHASE_STATUS_ACTIVE]
+    return STATUS_UPCOMING, _PHASE_STATUS_LABELS[STATUS_UPCOMING]
+
+
+def phase_duration_label(phase) -> str:
+    """Human readable duration of a phase, e.g. '3 months' or '2 weeks'."""
+    start = phase.start_date
+    end = phase.end_date
+    if not start or not end or end <= start:
+        return ""
+    months = (end.year - start.year) * 12 + (end.month - start.month)
+    if end.day < start.day:
+        months -= 1
+    if months >= 1:
+        return _n("%(count)s month", "%(count)s months", months) % {"count": months}
+
+    # Use the actual elapsed time so that phases shorter than a calendar
+    # day (including ones crossing midnight) are reported in hours or
+    # minutes instead of being rounded up to "1 day".
+    elapsed = end - start
+    days = elapsed.days
+    if days >= 7:
+        weeks = days // 7
+        return _n("%(count)s week", "%(count)s weeks", weeks) % {"count": weeks}
+    if days >= 1:
+        return _n("%(count)s day", "%(count)s days", days) % {"count": days}
+    hours = elapsed.seconds // 3600
+    if hours >= 1:
+        return _n("%(count)s hour", "%(count)s hours", hours) % {"count": hours}
+    minutes = elapsed.seconds // 60
+    if minutes >= 1:
+        return _n("%(count)s minute", "%(count)s minutes", minutes) % {"count": minutes}
+    return _("1 minute")
 
 
 def offline_event_participation_status(event: OfflineEvent) -> tuple[str, str]:

--- a/tests/projects/test_module_phases.py
+++ b/tests/projects/test_module_phases.py
@@ -1,0 +1,227 @@
+import pytest
+from dateutil.parser import parse
+from django.urls import reverse
+from freezegun import freeze_time
+
+from apps.ideas import phases as ideas_phases
+from apps.projects.timeline import phase_duration_label
+from apps.projects.timeline import phase_participation_status
+
+
+@pytest.mark.django_db
+def test_phase_participation_status_completed(phase_factory, module_factory):
+    module = module_factory()
+    phase = phase_factory(
+        module=module,
+        start_date=parse("2013-01-01 17:00:00 UTC"),
+        end_date=parse("2013-01-01 18:00:00 UTC"),
+    )
+    with freeze_time(parse("2013-01-02 18:00:00 UTC")):
+        status, label = phase_participation_status(phase)
+    assert status == "completed"
+
+
+@pytest.mark.django_db
+def test_phase_participation_status_active(phase_factory, module_factory):
+    module = module_factory()
+    phase = phase_factory(
+        module=module,
+        start_date=parse("2013-01-01 17:00:00 UTC"),
+        end_date=parse("2013-01-01 19:00:00 UTC"),
+    )
+    with freeze_time(parse("2013-01-01 18:00:00 UTC")):
+        status, label = phase_participation_status(phase)
+    assert status == "active"
+
+
+@pytest.mark.django_db
+def test_phase_participation_status_upcoming(phase_factory, module_factory):
+    module = module_factory()
+    phase = phase_factory(
+        module=module,
+        start_date=parse("2013-02-01 17:00:00 UTC"),
+        end_date=parse("2013-02-01 19:00:00 UTC"),
+    )
+    with freeze_time(parse("2013-01-01 18:00:00 UTC")):
+        status, label = phase_participation_status(phase)
+    assert status == "upcoming"
+
+
+@pytest.mark.django_db
+def test_phase_participation_status_without_end_date(phase_factory, module_factory):
+    # Matches a4's Phase.is_over: a phase without an end date is "over",
+    # never "active" (so module.active_phase stays None and the badge
+    # cannot contradict the "participation is not possible" notice).
+    module = module_factory()
+    phase = phase_factory(
+        module=module,
+        start_date=parse("2013-01-01 17:00:00 UTC"),
+        end_date=None,
+    )
+    with freeze_time(parse("2013-01-03 18:00:00 UTC")):
+        status, label = phase_participation_status(phase)
+    assert status == "completed"
+
+
+@pytest.mark.django_db
+def test_phase_participation_status_at_end_date(phase_factory, module_factory):
+    module = module_factory()
+    phase = phase_factory(
+        module=module,
+        start_date=parse("2013-01-01 17:00:00 UTC"),
+        end_date=parse("2013-01-05 18:00:00 UTC"),
+    )
+    with freeze_time(parse("2013-01-05 18:00:00 UTC")):
+        status, label = phase_participation_status(phase)
+    assert status == "completed"
+
+
+@pytest.mark.django_db
+def test_phase_participation_status_without_start_date(phase_factory, module_factory):
+    module = module_factory()
+    phase = phase_factory(
+        module=module,
+        start_date=None,
+        end_date=parse("2013-01-05 18:00:00 UTC"),
+    )
+    with freeze_time(parse("2013-01-03 18:00:00 UTC")):
+        status, label = phase_participation_status(phase)
+    assert status == "upcoming"
+
+
+@pytest.mark.django_db
+def test_phase_duration_label_days(phase_factory, module_factory):
+    module = module_factory()
+    phase = phase_factory(
+        module=module,
+        start_date=parse("2013-01-01 17:00:00 UTC"),
+        end_date=parse("2013-01-04 17:00:00 UTC"),
+    )
+    assert phase_duration_label(phase) == "3 days"
+
+
+@pytest.mark.django_db
+def test_phase_duration_label_weeks(phase_factory, module_factory):
+    module = module_factory()
+    phase = phase_factory(
+        module=module,
+        start_date=parse("2013-01-01 17:00:00 UTC"),
+        end_date=parse("2013-01-22 17:00:00 UTC"),
+    )
+    assert phase_duration_label(phase) == "3 weeks"
+
+
+@pytest.mark.django_db
+def test_phase_duration_label_months(phase_factory, module_factory):
+    module = module_factory()
+    phase = phase_factory(
+        module=module,
+        start_date=parse("2013-01-01 17:00:00 UTC"),
+        end_date=parse("2013-04-01 17:00:00 UTC"),
+    )
+    assert phase_duration_label(phase) == "3 months"
+
+
+@pytest.mark.django_db
+def test_phase_duration_label_same_day_hours(phase_factory, module_factory):
+    module = module_factory()
+    phase = phase_factory(
+        module=module,
+        start_date=parse("2013-01-01 09:00:00 UTC"),
+        end_date=parse("2013-01-01 13:00:00 UTC"),
+    )
+    assert phase_duration_label(phase) == "4 hours"
+
+
+@pytest.mark.django_db
+def test_phase_duration_label_hours_across_midnight(phase_factory, module_factory):
+    module = module_factory()
+    phase = phase_factory(
+        module=module,
+        start_date=parse("2013-01-01 23:00:00 UTC"),
+        end_date=parse("2013-01-02 01:00:00 UTC"),
+    )
+    assert phase_duration_label(phase) == "2 hours"
+
+
+@pytest.mark.django_db
+def test_phase_duration_label_minutes(phase_factory, module_factory):
+    module = module_factory()
+    phase = phase_factory(
+        module=module,
+        start_date=parse("2013-01-01 10:00:00 UTC"),
+        end_date=parse("2013-01-01 10:30:00 UTC"),
+    )
+    assert phase_duration_label(phase) == "30 minutes"
+
+
+@pytest.mark.django_db
+def test_phase_duration_label_empty_without_end(phase_factory, module_factory):
+    module = module_factory()
+    phase = phase_factory(
+        module=module,
+        start_date=parse("2013-01-01 17:00:00 UTC"),
+        end_date=None,
+    )
+    assert phase_duration_label(phase) == ""
+
+
+def _phase_for_module(phase_factory, module, weight, start, end, name):
+    content = ideas_phases.CollectPhase()
+    return phase_factory(
+        module=module,
+        weight=weight,
+        phase_content=content,
+        name=name,
+        start_date=parse(start),
+        end_date=parse(end),
+    )
+
+
+@pytest.mark.django_db
+def test_module_detail_renders_all_phases_with_status(
+    client, phase_factory, module_factory, organisation
+):
+    module = module_factory(project__organisation=organisation)
+    completed = _phase_for_module(
+        phase_factory,
+        module,
+        0,
+        "2013-01-01 17:00:00 UTC",
+        "2013-01-01 18:00:00 UTC",
+        "Collect ideas",
+    )
+    active = _phase_for_module(
+        phase_factory,
+        module,
+        1,
+        "2013-01-02 17:00:00 UTC",
+        "2013-01-05 18:00:00 UTC",
+        "Discuss",
+    )
+    upcoming = _phase_for_module(
+        phase_factory,
+        module,
+        2,
+        "2013-01-10 17:00:00 UTC",
+        "2013-01-12 18:00:00 UTC",
+        "Vote",
+    )
+
+    url = reverse(
+        "module-detail",
+        kwargs={
+            "organisation_slug": organisation.slug,
+            "module_slug": module.slug,
+        },
+    )
+    with freeze_time(parse("2013-01-03 18:00:00 UTC")):
+        response = client.get(url)
+    assert response.status_code == 200
+
+    content = response.content.decode()
+    for phase in (completed, active, upcoming):
+        assert phase.name in content
+    assert "Completed" in content
+    assert "Active" in content
+    assert "Upcoming" in content


### PR DESCRIPTION
**Tasks**
- [x] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [x] Changelog


:.::..:::::: [Aligned Asana Task](https://app.asana.com/1/1175467295883992/project/1208559589495764/task/1218040286405806) ::.:.::.::::