### PR TITLE
Dockerization: Granian instead of runserver

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -46,10 +46,14 @@ RUN pip install --no-cache-dir -r requirements/dev.txt
 COPY . .
 COPY --from=assets /app/adhocracy-plus/static /app/adhocracy-plus/static
 
+# Collect static files so the WSGI server (granian) can serve them via
+# WhiteNoise; the dev server (runserver) is not used in containers.
+RUN python manage.py collectstatic --noinput
+
 COPY docker/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
 EXPOSE 8004
 
 ENTRYPOINT ["/entrypoint.sh"]
-CMD ["python", "manage.py", "runserver", "0.0.0.0:8004"]
+CMD ["granian", "--interface", "wsgi", "--host", "0.0.0.0", "--port", "8004", "--log-level", "warning", "adhocracy-plus.config.wsgi:application"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -48,12 +48,12 @@ services:
       - media_data:/app/media
       - aplus_config:/data:ro
     healthcheck:
-      test: ["CMD-SHELL", "python manage.py migrate --check"]
-      interval: 5s
-      timeout: 120s
-      retries: 60
-      start_period: 300s
-    command: ["python", "manage.py", "runserver", "0.0.0.0:8004"]
+      test: ["CMD", "python", "-c", "import socket,sys; s=socket.create_connection(('localhost',8004),2); s.close()"]
+      interval: 60s
+      timeout: 5s
+      retries: 3
+      start_period: 90s
+    command: ["granian", "--interface", "wsgi", "--host", "0.0.0.0", "--port", "8004", "--log-level", "warning", "adhocracy-plus.config.wsgi:application"]
 
   worker:
     build: .

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -39,4 +39,5 @@ python-dateutil==2.9.0.post0
 python-dotenv==1.2.2
 rules==3.5
 celery==5.4.0
+granian==2.8.2
 django-polymorphic==4.8


### PR DESCRIPTION
**Tasks**
- [x] PR name contains story or task reference
- [ ] Documentation (docs and inline)
- [ ] Tests (including n+1 and django_assert_num_queries where applicable)
- [ ] Changelog
